### PR TITLE
test: migrate integration test to runetes/maiao-tests

### DIFF
--- a/pkg/api/github_test.go
+++ b/pkg/api/github_test.go
@@ -293,7 +293,7 @@ func TestNewGitHubUpserter(t *testing.T) {
 func TestGitHubUpsert(t *testing.T) {
 	gh, err := NewGitHubUpserter(context.Background(), &transport.Endpoint{
 		Host: "github.com",
-		Path: "adevinta/maiao-tests",
+		Path: "runetes/maiao-tests",
 	})
 	if err != nil {
 		t.Skipf("Failed to initialise GitHub upserter, " +
@@ -303,16 +303,16 @@ func TestGitHubUpsert(t *testing.T) {
 	u := uuid.New().String()
 	head := "tests/go/upsert/" + u
 	t.Cleanup(func() {
-		gh.Git.DeleteRef(context.Background(), "adevinta", "maiao-tests", "refs/heads/"+head)
+		gh.Git.DeleteRef(context.Background(), "runetes", "maiao-tests", "refs/heads/"+head)
 	})
 
-	rc, _, err := gh.Repositories.GetCommit(context.Background(), "adevinta", "maiao-tests", "main", &github.ListOptions{})
+	rc, _, err := gh.Repositories.GetCommit(context.Background(), "runetes", "maiao-tests", "main", &github.ListOptions{})
 	require.NoError(t, err)
 
-	c, _, err := gh.Git.CreateCommit(context.Background(), "adevinta", "maiao-tests", &github.Commit{
+	c, _, err := gh.Git.CreateCommit(context.Background(), "runetes", "maiao-tests", &github.Commit{
 		Message: github.String("Test commit " + u),
 		Tree:    rc.Commit.Tree,
-		Parents: rc.Parents,
+		Parents: []*github.Commit{{SHA: rc.SHA}},
 	})
 	if err != nil {
 		if ghError, ok := err.(*github.ErrorResponse); ok {
@@ -324,7 +324,7 @@ func TestGitHubUpsert(t *testing.T) {
 	}
 	require.NoError(t, err)
 	require.NotNil(t, c)
-	_, _, err = gh.Git.CreateRef(context.Background(), "adevinta", "maiao-tests", &github.Reference{
+	_, _, err = gh.Git.CreateRef(context.Background(), "runetes", "maiao-tests", &github.Reference{
 		Ref: github.String("refs/heads/" + head),
 		Object: &github.GitObject{
 			SHA: c.SHA,
@@ -337,7 +337,7 @@ func TestGitHubUpsert(t *testing.T) {
 		id, err := strconv.Atoi(pr.ID)
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			gh.PullRequests.Edit(context.Background(), "adevinta", "maiao-tests", id, &github.PullRequest{
+			gh.PullRequests.Edit(context.Background(), "runetes", "maiao-tests", id, &github.PullRequest{
 				State: github.String("Closed"),
 			})
 		})


### PR DESCRIPTION
Problem
=====

The integration test in TestGitHubUpsert targets adevinta/maiao-tests
which is no longer accessible from the current development environment.
Additionally, the test creates commits with rc.Parents (grandparent),
producing orphan branches that fail with "no history in common".

Goal
=====

Make the integration test runnable against our own test repository and
fix the commit parentage so branches share history with main.

Solution
=====

Point TestGitHubUpsert at runetes/maiao-tests and use rc.SHA (main's
HEAD) as the parent for new test commits instead of rc.Parents.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
chore(deps): bump github.com/google/go-github from v55 to v90 (#2)
</summary>
Problem
=====

go-github v55 does not include the PullRequestStack types or the
WithVersion request option needed to call the GitHub Stacked PRs API
(version 2026-03-10).

Goal
=====

Upgrade to the latest go-github release to access native stack types
and the versioned request API required for stack management.

Solution
=====

Upgrade to go-github/v90 and adapt to breaking changes: NewClient now
uses functional options, CreatePullRequest replaces NewPullRequest,
BaseURL is a method returning string, and CreateCommit/CreateRef
signatures changed to value receivers.
</details>
<details>
<summary>
feat: add Stack option to ReviewOptions with git config support (#3)
</summary>
Problem
=====

There is no way to control whether Maiao should register PRs as a
GitHub native stack. The feature needs an opt-in mechanism that
defaults to automatic detection.

Goal
=====

Allow users to configure native stack behavior via git config without
requiring a CLI flag on every invocation.

Solution
=====

Add a Stack field to ReviewOptions populated from git config key
maiao.useNativeStack. Supports "auto" (default — probe and use if
available), "true" (require), and "false" (disable).
</details>
<details>
<summary>
feat: implement StackManager interface and GitHub client (#4)
</summary>
Problem
=====

Maiao creates PRs with proper base-branch chains but GitHub does not
recognize them as a native stack, so users miss the stack UI,
cascading rebases, and one-click merge-all.

Goal
=====

Provide a clean abstraction for managing GitHub native stacks that can
be called after PR creation and degrades gracefully on unsupported
instances.

Solution
=====

Define a StackManager interface (CreateOrUpdateStack, GetStack,
Available) and implement it using the GitHub REST API at
/repos/{owner}/{repo}/stacks with version header 2026-03-10. Expose
StackManager() on the PullRequester interface. Availability is probed
once and cached via sync.Once.
</details>
<details>
<summary>
test: add unit tests for native stack registration (#5)
</summary>
Problem
=====

The new StackManager implementation and registerNativeStack
integration point have no test coverage, making regressions hard to
catch.

Goal
=====

Verify that stack registration behaves correctly across all
configuration modes and error paths.

Solution
=====

Add tests for GitHubStackManager (availability probing, caching,
create/update, existing stack detection, API version header) and for
registerNativeStack (skipped when disabled, skipped when unavailable,
called when available, graceful on error, nil StackManager is a noop).
</details>
</details>
</details>