### PR TITLE
[need #2] feat: add Stack option to ReviewOptions with git config support

### DIFF
--- a/pkg/cmd/review.go
+++ b/pkg/cmd/review.go
@@ -49,5 +49,20 @@ func review(cmd *cobra.Command, args []string) error {
 		Branch:         branch,
 		WorkInProgress: cmd.Flag("work-in-progress").Value.String() != "false",
 		Ready:          cmd.Flag("ready").Value.String() != "false",
+		Stack:          stackOption(repo),
 	})
+}
+
+func stackOption(repo *git.Repository) string {
+	cfg, err := repo.Config()
+	if err != nil || cfg.Raw == nil {
+		return "auto"
+	}
+	v := cfg.Raw.Section("maiao").Option("useNativeStack")
+	switch v {
+	case "true", "false":
+		return v
+	default:
+		return "auto"
+	}
 }

--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -31,6 +31,7 @@ type ReviewOptions struct {
 	Topic          string
 	WorkInProgress bool
 	Ready          bool
+	Stack          string
 }
 
 type change struct {


### PR DESCRIPTION
Problem
=====

There is no way to control whether maiao should use GitHub native
stacked PRs when creating review chains.

Goal
=====

Allow users to opt in/out of native stack registration via git
config, with a sensible default that auto-detects availability.

Solution
=====

- Add Stack field to ReviewOptions (values: "auto", "true", "false").
- Read maiao.useNativeStack from git config in cmd/review.go.
- Default is "auto": probe the API and use if available, skip
  silently otherwise.
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
chore(deps): bump github.com/google/go-github from v55 to v90 (#2)
</summary>
Problem
=====

The go-github v55 library does not support the GitHub Stacks API
(version 2026-03-10) needed for native stacked PRs.

Goal
=====

Upgrade to go-github v90, the latest release, to gain access to
the newer API surface and request option patterns.

Solution
=====

- Upgrade go-github from v55 to v90 in go.mod.
- Adapt to breaking changes: NewClient uses functional options,
  NewPullRequest is now CreatePullRequest (value type with plain
  string Base/Head fields), CreateRef uses a value type.
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
feat: implement StackManager interface with disk-cached availability (#4)
</summary>
Problem
=====

After adding the Stack option to ReviewOptions, we need the actual
StackManager implementation that talks to the GitHub Stacks API
(version 2026-03-10) and tests to verify the behavior.

The availability probe makes a network request on every `git review`
invocation, which is wasteful given GitHub rate limits.

Goal
=====

Implement the StackManager interface, integrate it into the review
flow, and cache the availability check result in git config so it's
only probed once per day.

Solution
=====

- Add StackManager interface (stack.go) and GitHubStackManager
  implementation (stack_github.go) using raw HTTP with WithVersion.
- Expose StackManager from PullRequester interface.
- Cache availability result in git config (maiao.stackApiAvailable +
  maiao.stackApiCheckedAt) with a 24h TTL to reduce rate limit usage.
- Add unit tests using func-field mock pattern consistent with the
  rest of the repo.
</details>
</details>
</details>