### PR TITLE
feat: implement StackManager interface with disk-cached availability

### DIFF
--- a/pkg/api/github.go
+++ b/pkg/api/github.go
@@ -21,9 +21,10 @@ import (
 type GitHub struct {
 	GraphQLClient *api.GraphQLClient
 	*github.Client
-	Host       string
-	Owner      string
-	Repository string
+	Host         string
+	Owner        string
+	Repository   string
+	stackManager *GitHubStackManager
 }
 
 // RepoName implements the ghrepo.Interface interface required to call the github graphql API from https://github.com/cli/cli
@@ -168,6 +169,11 @@ func (g *GitHub) DefaultBranch(ctx context.Context) string {
 	return repo.GetDefaultBranch()
 }
 
+// StackManager returns the GitHub native stack manager.
+func (g *GitHub) StackManager() StackManager {
+	return g.stackManager
+}
+
 // LinkedTopicIssues returns the search URL for linked issues
 func (g *GitHub) LinkedTopicIssues(topicSearchString string) string {
 	values := url.Values{}
@@ -216,6 +222,7 @@ func NewGitHubUpserter(ctx context.Context, endpoint *transport.Endpoint) (*GitH
 		Repository:    repo.GetName(),
 		Client:        client,
 		GraphQLClient: graphQLClient,
+		stackManager:  NewGitHubStackManager(client, repo.GetOwner().GetLogin(), repo.GetName()),
 	}
 	log.ForContext(ctx).Trace("initialized github client")
 	return gh, nil

--- a/pkg/api/pullRequester.go
+++ b/pkg/api/pullRequester.go
@@ -18,6 +18,8 @@ type PullRequester interface {
 	Ensure(context.Context, PullRequestOptions) (*PullRequest, bool, error)
 	LinkedTopicIssues(topicSearchString string) string
 	DefaultBranch(context.Context) string
+	// StackManager returns the stack manager if native stacks are supported, or nil.
+	StackManager() StackManager
 }
 
 // PullRequestOptions are the options available to create or update a pull request

--- a/pkg/api/stack.go
+++ b/pkg/api/stack.go
@@ -1,0 +1,20 @@
+package api
+
+import "context"
+
+// StackManager defines the interface for GitHub native stack operations.
+type StackManager interface {
+	// CreateOrUpdateStack registers a set of PRs as a GitHub native stack.
+	// prNumbers must be ordered bottom-to-top (first targets the base branch).
+	CreateOrUpdateStack(ctx context.Context, prNumbers []int) (*Stack, error)
+	// GetStack retrieves the stack associated with a given PR number.
+	GetStack(ctx context.Context, prNumber int) (*Stack, error)
+	// Available reports whether the GitHub Stack API is supported on this instance.
+	Available(ctx context.Context) bool
+}
+
+// Stack represents a GitHub native stack of pull requests.
+type Stack struct {
+	ID  string
+	PRs []int
+}

--- a/pkg/api/stack_github.go
+++ b/pkg/api/stack_github.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/adevinta/maiao/pkg/log"
+	"github.com/google/go-github/v90/github"
+)
+
+const stackAPIVersion = "2026-03-10"
+
+// GitHubStackManager implements StackManager using the GitHub REST API.
+type GitHubStackManager struct {
+	client     *github.Client
+	owner      string
+	repository string
+}
+
+// NewGitHubStackManager creates a new GitHubStackManager.
+func NewGitHubStackManager(client *github.Client, owner, repository string) *GitHubStackManager {
+	return &GitHubStackManager{
+		client:     client,
+		owner:      owner,
+		repository: repository,
+	}
+}
+
+func (s *GitHubStackManager) Available(ctx context.Context) bool {
+	url := fmt.Sprintf("repos/%s/%s/stacks?per_page=1", s.owner, s.repository)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, url, nil, github.WithVersion(stackAPIVersion))
+	if err != nil {
+		return false
+	}
+	resp, err := s.client.Do(req, nil)
+	if err != nil {
+		if resp != nil && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnsupportedMediaType) {
+			return false
+		}
+		return false
+	}
+	return resp.StatusCode == http.StatusOK
+}
+
+type createStackRequest struct {
+	PullRequests []int `json:"pull_requests"`
+}
+
+type stackPullRequest struct {
+	Number int `json:"number"`
+}
+
+type stackResponse struct {
+	ID           int64              `json:"id"`
+	Number       int                `json:"number"`
+	PullRequests []stackPullRequest `json:"pull_requests"`
+}
+
+func (s *GitHubStackManager) CreateOrUpdateStack(ctx context.Context, prNumbers []int) (*Stack, error) {
+	existing, err := s.GetStack(ctx, prNumbers[0])
+	if err == nil && existing != nil {
+		log.ForContext(ctx).WithField("stackID", existing.ID).Debug("stack already exists")
+		return existing, nil
+	}
+
+	url := fmt.Sprintf("repos/%s/%s/stacks", s.owner, s.repository)
+	body := createStackRequest{PullRequests: prNumbers}
+	req, err := s.client.NewRequest(ctx, http.MethodPost, url, body, github.WithVersion(stackAPIVersion))
+	if err != nil {
+		return nil, fmt.Errorf("creating stack request: %w", err)
+	}
+
+	var resp stackResponse
+	_, err = s.client.Do(req, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("creating stack: %w", err)
+	}
+
+	log.ForContext(ctx).WithField("stackID", resp.ID).Debug("registered GitHub native stack")
+	return stackFromResponse(&resp), nil
+}
+
+func (s *GitHubStackManager) GetStack(ctx context.Context, prNumber int) (*Stack, error) {
+	url := fmt.Sprintf("repos/%s/%s/stacks?pull_request=%d", s.owner, s.repository, prNumber)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, url, nil, github.WithVersion(stackAPIVersion))
+	if err != nil {
+		return nil, err
+	}
+
+	var stacks []stackResponse
+	_, err = s.client.Do(req, &stacks)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(stacks) == 0 {
+		return nil, nil
+	}
+
+	return stackFromResponse(&stacks[0]), nil
+}
+
+func stackFromResponse(resp *stackResponse) *Stack {
+	prs := make([]int, len(resp.PullRequests))
+	for i, p := range resp.PullRequests {
+		prs[i] = p.Number
+	}
+	return &Stack{
+		ID:  fmt.Sprintf("%d", resp.ID),
+		PRs: prs,
+	}
+}

--- a/pkg/api/stack_github_test.go
+++ b/pkg/api/stack_github_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubStackManager_Available_ReturnsTrue(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Contains(t, r.URL.Path, "/repos/owner/repo/stacks")
+		assert.Equal(t, "2026-03-10", r.Header.Get("X-GitHub-Api-Version"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	assert.True(t, mgr.Available(context.Background()))
+}
+
+func TestGitHubStackManager_Available_ReturnsFalseOn404(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"message":"Not Found"}`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	assert.False(t, mgr.Available(context.Background()))
+}
+
+func TestGitHubStackManager_CreateOrUpdateStack(t *testing.T) {
+	requestCount := 0
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "pull_request=1"):
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`[]`)),
+			}, nil
+		case r.Method == http.MethodPost:
+			var body createStackRequest
+			err := json.NewDecoder(r.Body).Decode(&body)
+			require.NoError(t, err)
+			assert.Equal(t, []int{1, 2, 3}, body.PullRequests)
+
+			resp := stackResponse{
+				ID:     42,
+				Number: 1,
+				PullRequests: []stackPullRequest{
+					{Number: 1},
+					{Number: 2},
+					{Number: 3},
+				},
+			}
+			b, _ := json.Marshal(resp)
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(string(b))),
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	stack, err := mgr.CreateOrUpdateStack(context.Background(), []int{1, 2, 3})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+	assert.Equal(t, "42", stack.ID)
+	assert.Equal(t, []int{1, 2, 3}, stack.PRs)
+}
+
+func TestGitHubStackManager_CreateOrUpdateStack_ReturnsExistingStack(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			resp := []stackResponse{{
+				ID:     99,
+				Number: 1,
+				PullRequests: []stackPullRequest{
+					{Number: 1},
+					{Number: 2},
+				},
+			}}
+			b, _ := json.Marshal(resp)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(string(b))),
+			}, nil
+		}
+		t.Fatal("should not POST when stack already exists")
+		return nil, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	stack, err := mgr.CreateOrUpdateStack(context.Background(), []int{1, 2})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+	assert.Equal(t, "99", stack.ID)
+}
+
+func TestGitHubStackManager_GetStack_ReturnsNilWhenEmpty(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	stack, err := mgr.GetStack(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Nil(t, stack)
+}
+
+func TestGitHubStackManager_AvailableChecksAPIVersionHeader(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "2026-03-10", r.Header.Get("X-GitHub-Api-Version"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	mgr.Available(context.Background())
+}
+

--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/adevinta/maiao/pkg/api"
 	"github.com/adevinta/maiao/pkg/credentials"
@@ -288,7 +291,108 @@ func sendPrs(ctx context.Context, repo lgit.Repository, options ReviewOptions, b
 		}
 		log.ForContext(ctx).WithFields(logrus.Fields{"prOptions": opts, "change": change}).Trace("PR has been updated with parent ")
 	}
+
+	if len(changes) > 1 {
+		registerNativeStack(ctx, prAPI, options, changes)
+	}
+
 	return nil
+}
+
+func registerNativeStack(ctx context.Context, prAPI api.PullRequester, options ReviewOptions, changes []*change) {
+	if options.Stack == "false" {
+		return
+	}
+
+	stackMgr := prAPI.StackManager()
+	if stackMgr == nil {
+		if options.Stack == "true" {
+			log.ForContext(ctx).Warn("native stacks requested but not supported by this GitHub instance")
+		}
+		return
+	}
+
+	if !stackAvailable(ctx, stackMgr, options, options.RepoPath) {
+		return
+	}
+
+	prNumbers := make([]int, 0, len(changes))
+	for _, change := range changes {
+		id, err := strconv.Atoi(change.pr.ID)
+		if err != nil {
+			log.ForContext(ctx).WithError(err).Warn("failed to parse PR number for stack registration")
+			return
+		}
+		prNumbers = append(prNumbers, id)
+	}
+
+	stack, err := stackMgr.CreateOrUpdateStack(ctx, prNumbers)
+	if err != nil {
+		log.ForContext(ctx).WithError(err).Warn("failed to register native stack")
+		return
+	}
+	log.ForContext(ctx).WithField("stackID", stack.ID).WithField("prCount", len(stack.PRs)).Debug("registered native stack")
+}
+
+const stackCacheTTL = 24 * time.Hour
+
+func stackAvailable(ctx context.Context, stackMgr api.StackManager, options ReviewOptions, repoPath string) bool {
+	cached, cachedAt := readStackAvailabilityCache(repoPath)
+	if cachedAt != nil && time.Since(*cachedAt) < stackCacheTTL {
+		log.ForContext(ctx).Debug("using cached stack API availability")
+		return cached
+	}
+
+	available := stackMgr.Available(ctx)
+	writeStackAvailabilityCache(repoPath, available)
+
+	if !available && options.Stack == "true" {
+		log.ForContext(ctx).Warn("native stacks requested but not available on this GitHub instance")
+	}
+	return available
+}
+
+func readStackAvailabilityCache(repoPath string) (available bool, checkedAt *time.Time) {
+	cmd := exec.Command("git", "config", "--local", "maiao.stackApiCheckedAt")
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return false, nil
+	}
+	ts, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return false, nil
+	}
+	t := time.Unix(ts, 0)
+
+	cmd = exec.Command("git", "config", "--local", "maiao.stackApiAvailable")
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	out, err = cmd.Output()
+	if err != nil {
+		return false, nil
+	}
+	return strings.TrimSpace(string(out)) == "true", &t
+}
+
+func writeStackAvailabilityCache(repoPath string, available bool) {
+	val := "false"
+	if available {
+		val = "true"
+	}
+	cmd := exec.Command("git", "config", "--local", "maiao.stackApiAvailable", val)
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	cmd.Run()
+	cmd = exec.Command("git", "config", "--local", "maiao.stackApiCheckedAt", strconv.FormatInt(time.Now().Unix(), 10))
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	cmd.Run()
 }
 
 func defaultBranchOption(ctx context.Context, repo lgit.Repository, prAPI api.PullRequester, options *ReviewOptions) {

--- a/pkg/maiao/review_test.go
+++ b/pkg/maiao/review_test.go
@@ -9,8 +9,10 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/adevinta/maiao/pkg/api"
 	"github.com/adevinta/maiao/pkg/log"
@@ -141,6 +143,10 @@ func (a *testAPI) DefaultBranch(ctx context.Context) string {
 		return a.DefaultBranchFunc(ctx)
 	}
 	return "DefaultBranch not implemented"
+}
+
+func (a *testAPI) StackManager() api.StackManager {
+	return nil
 }
 
 func TestDefaultOptionsUsesGitDefaults(t *testing.T) {
@@ -538,6 +544,154 @@ type nopWriteCloser struct {
 
 func (n *nopWriteCloser) Close() error {
 	return nil
+}
+
+type testStackManager struct {
+	available            func(context.Context) bool
+	createOrUpdateStack  func(context.Context, []int) (*api.Stack, error)
+	getStack             func(context.Context, int) (*api.Stack, error)
+	createOrUpdateCalled int
+	lastPRNumbers        []int
+}
+
+func (m *testStackManager) Available(ctx context.Context) bool {
+	if m.available == nil {
+		return false
+	}
+	return m.available(ctx)
+}
+
+func (m *testStackManager) CreateOrUpdateStack(ctx context.Context, prNumbers []int) (*api.Stack, error) {
+	m.createOrUpdateCalled++
+	m.lastPRNumbers = prNumbers
+	if m.createOrUpdateStack == nil {
+		return nil, errors.New("CreateOrUpdateStack not implemented")
+	}
+	return m.createOrUpdateStack(ctx, prNumbers)
+}
+
+func (m *testStackManager) GetStack(ctx context.Context, prNumber int) (*api.Stack, error) {
+	if m.getStack == nil {
+		return nil, errors.New("GetStack not implemented")
+	}
+	return m.getStack(ctx, prNumber)
+}
+
+type testAPIWithStack struct {
+	testAPI
+	stackMgr api.StackManager
+}
+
+func (a *testAPIWithStack) StackManager() api.StackManager {
+	return a.stackMgr
+}
+
+func stackTestRepo(t *testing.T) string {
+	t.Helper()
+	d, err := os.MkdirTemp("", "stack-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(d) })
+	gitCommand(t, d, "init")
+	gitCommand(t, d, "config", "user.email", "test@test.com")
+	gitCommand(t, d, "config", "user.name", "Test")
+	gitCommand(t, d, "commit", "--allow-empty", "-m", "init")
+	return d
+}
+
+func TestRegisterNativeStack_SkippedWhenStackFalse(t *testing.T) {
+	mgr := &testStackManager{
+		available: func(context.Context) bool { return true },
+		createOrUpdateStack: func(_ context.Context, _ []int) (*api.Stack, error) {
+			return &api.Stack{ID: "1", PRs: []int{1, 2}}, nil
+		},
+	}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "false", RepoPath: stackTestRepo(t)}, changes)
+	assert.Equal(t, 0, mgr.createOrUpdateCalled)
+}
+
+func TestRegisterNativeStack_SkippedWhenNotAvailableAndAuto(t *testing.T) {
+	mgr := &testStackManager{
+		available: func(context.Context) bool { return false },
+	}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "auto", RepoPath: stackTestRepo(t)}, changes)
+	assert.Equal(t, 0, mgr.createOrUpdateCalled)
+}
+
+func TestRegisterNativeStack_CallsCreateOrUpdateWhenAvailable(t *testing.T) {
+	mgr := &testStackManager{
+		available: func(context.Context) bool { return true },
+		createOrUpdateStack: func(_ context.Context, _ []int) (*api.Stack, error) {
+			return &api.Stack{ID: "42", PRs: []int{10, 20, 30}}, nil
+		},
+	}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "10"}},
+		{pr: &api.PullRequest{ID: "20"}},
+		{pr: &api.PullRequest{ID: "30"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "auto", RepoPath: stackTestRepo(t)}, changes)
+	assert.Equal(t, 1, mgr.createOrUpdateCalled)
+	assert.Equal(t, []int{10, 20, 30}, mgr.lastPRNumbers)
+}
+
+func TestRegisterNativeStack_GracefulOnError(t *testing.T) {
+	mgr := &testStackManager{
+		available: func(context.Context) bool { return true },
+		createOrUpdateStack: func(_ context.Context, _ []int) (*api.Stack, error) {
+			return nil, errors.New("API error")
+		},
+	}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "true", RepoPath: stackTestRepo(t)}, changes)
+	assert.Equal(t, 1, mgr.createOrUpdateCalled)
+}
+
+func TestRegisterNativeStack_NilStackManagerWithAutoIsNoop(t *testing.T) {
+	prAPI := &testAPI{}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "auto", RepoPath: stackTestRepo(t)}, changes)
+}
+
+func TestRegisterNativeStack_UsesCachedAvailability(t *testing.T) {
+	d := stackTestRepo(t)
+	gitCommand(t, d, "config", "maiao.stackApiAvailable", "true")
+	gitCommand(t, d, "config", "maiao.stackApiCheckedAt", strconv.FormatInt(time.Now().Unix(), 10))
+
+	availableCalled := false
+	mgr := &testStackManager{
+		available: func(context.Context) bool {
+			availableCalled = true
+			return true
+		},
+		createOrUpdateStack: func(_ context.Context, _ []int) (*api.Stack, error) {
+			return &api.Stack{ID: "1", PRs: []int{1}}, nil
+		},
+	}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "auto", RepoPath: d}, changes)
+	assert.False(t, availableCalled, "should use cached value, not call Available()")
+	assert.Equal(t, 1, mgr.createOrUpdateCalled)
 }
 
 func init() {


### PR DESCRIPTION
Problem
=====

After adding the Stack option to ReviewOptions, we need the actual
StackManager implementation that talks to the GitHub Stacks API
(version 2026-03-10) and tests to verify the behavior.

The availability probe makes a network request on every `git review`
invocation, which is wasteful given GitHub rate limits.

Goal
=====

Implement the StackManager interface, integrate it into the review
flow, and cache the availability check result in git config so it's
only probed once per day.

Solution
=====

- Add StackManager interface (stack.go) and GitHubStackManager
  implementation (stack_github.go) using raw HTTP with WithVersion.
- Expose StackManager from PullRequester interface.
- Cache availability result in git config (maiao.stackApiAvailable +
  maiao.stackApiCheckedAt) with a 24h TTL to reduce rate limit usage.
- Add unit tests using func-field mock pattern consistent with the
  rest of the repo.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
chore: migrate Homebrew formula and docs from adevinta to runetes (#8)
</summary>
Problem
=======

All URLs, badges, and references still pointed to the old
adevinta/maiao repository which will become unmaintained.
Users who installed via `brew tap adevinta/maiao` have no
guidance on how to switch to the new tap.

Goal
====

Point the project's Homebrew formula, documentation, and CI
workflows to runetes/maiao and provide a clear migration path
for existing users.

Solution
========

- Update HomebrewFormula/maiao.rb URLs and version suffix to
  runetes/maiao.
- Update all release/issue links in docs to runetes/maiao.
- Add a "Migrating from adevinta/maiao" section in
  getting-started.md with untap/tap/reinstall instructions.
- Fix reusable workflow reference in release.yaml.
</details>
<details>
<summary>
feat: automate releases with release-please and formula updates (#9)
</summary>
Problem
=======

Releasing a new version requires manually pushing a git tag and
then manually editing the Homebrew formula to update the tag and
revision fields. This means `brew upgrade maiao` stays stale
until someone remembers to update the formula.

Goal
====

Fully automated release pipeline: merge to main with conventional
commits → automatic versioning → build and publish → Homebrew
formula stays in sync without manual intervention.

Solution
========

- Add release-please workflow and configuration to automatically
  create release PRs based on conventional commits.
- Change release.yaml trigger from tag push to release published,
  so it fires after release-please creates the GitHub Release.
- Add an update-formula job to release.yaml that updates the
  tag and revision in HomebrewFormula/maiao.rb and pushes to
  main with [skip ci].
</details>
</details>
</details>