### PR TITLE
[need #4] test: add unit tests for native stack registration

### DIFF
--- a/pkg/api/stack_github_test.go
+++ b/pkg/api/stack_github_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v90/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubStackManager_Available_ReturnsTrue(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Contains(t, r.URL.Path, "/repos/owner/repo/stacks")
+		assert.Equal(t, "2026-03-10", r.Header.Get("X-GitHub-Api-Version"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	assert.True(t, mgr.Available(context.Background()))
+}
+
+func TestGitHubStackManager_Available_ReturnsFalseOn404(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(`{"message":"Not Found"}`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	assert.False(t, mgr.Available(context.Background()))
+}
+
+func TestGitHubStackManager_Available_CachesResult(t *testing.T) {
+	calls := 0
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	mgr.Available(context.Background())
+	mgr.Available(context.Background())
+	assert.Equal(t, 1, calls)
+}
+
+func TestGitHubStackManager_CreateOrUpdateStack(t *testing.T) {
+	requestCount := 0
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "pull_request=1"):
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`[]`)),
+			}, nil
+		case r.Method == http.MethodPost:
+			var body createStackRequest
+			err := json.NewDecoder(r.Body).Decode(&body)
+			require.NoError(t, err)
+			assert.Equal(t, []int{1, 2, 3}, body.PullRequests)
+
+			resp := stackResponse{
+				ID:     42,
+				Number: 1,
+				PullRequests: []stackPullRequest{
+					{Number: 1},
+					{Number: 2},
+					{Number: 3},
+				},
+			}
+			b, _ := json.Marshal(resp)
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(strings.NewReader(string(b))),
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	stack, err := mgr.CreateOrUpdateStack(context.Background(), []int{1, 2, 3})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+	assert.Equal(t, "42", stack.ID)
+	assert.Equal(t, []int{1, 2, 3}, stack.PRs)
+}
+
+func TestGitHubStackManager_CreateOrUpdateStack_ReturnsExistingStack(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			resp := []stackResponse{{
+				ID:     99,
+				Number: 1,
+				PullRequests: []stackPullRequest{
+					{Number: 1},
+					{Number: 2},
+				},
+			}}
+			b, _ := json.Marshal(resp)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(string(b))),
+			}, nil
+		}
+		t.Fatal("should not POST when stack already exists")
+		return nil, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	stack, err := mgr.CreateOrUpdateStack(context.Background(), []int{1, 2})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+	assert.Equal(t, "99", stack.ID)
+}
+
+func TestGitHubStackManager_GetStack_ReturnsNilWhenEmpty(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	stack, err := mgr.GetStack(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Nil(t, stack)
+}
+
+func TestGitHubStackManager_AvailableChecksAPIVersionHeader(t *testing.T) {
+	client := newTestClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "2026-03-10", r.Header.Get("X-GitHub-Api-Version"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}))
+
+	mgr := NewGitHubStackManager(client, "owner", "repo")
+	mgr.Available(context.Background())
+}
+
+func newTestClientFromFunc(rt func(*http.Request) (*http.Response, error)) *github.Client {
+	c, _ := github.NewClient(github.WithHTTPClient(&http.Client{Transport: roundTripperFunc(rt)}))
+	return c
+}

--- a/pkg/maiao/review_test.go
+++ b/pkg/maiao/review_test.go
@@ -143,6 +143,10 @@ func (a *testAPI) DefaultBranch(ctx context.Context) string {
 	return "DefaultBranch not implemented"
 }
 
+func (a *testAPI) StackManager() api.StackManager {
+	return nil
+}
+
 func TestDefaultOptionsUsesGitDefaults(t *testing.T) {
 	opts := ReviewOptions{}
 	repo := &testRepository{}
@@ -538,6 +542,98 @@ type nopWriteCloser struct {
 
 func (n *nopWriteCloser) Close() error {
 	return nil
+}
+
+type mockStackManager struct {
+	available            bool
+	createOrUpdateCalled int
+	lastPRNumbers        []int
+	stack                *api.Stack
+	err                  error
+}
+
+func (m *mockStackManager) Available(_ context.Context) bool {
+	return m.available
+}
+
+func (m *mockStackManager) CreateOrUpdateStack(_ context.Context, prNumbers []int) (*api.Stack, error) {
+	m.createOrUpdateCalled++
+	m.lastPRNumbers = prNumbers
+	return m.stack, m.err
+}
+
+func (m *mockStackManager) GetStack(_ context.Context, _ int) (*api.Stack, error) {
+	return m.stack, m.err
+}
+
+type testAPIWithStack struct {
+	testAPI
+	stackMgr api.StackManager
+}
+
+func (a *testAPIWithStack) StackManager() api.StackManager {
+	return a.stackMgr
+}
+
+func TestRegisterNativeStack_SkippedWhenStackFalse(t *testing.T) {
+	mgr := &mockStackManager{available: true, stack: &api.Stack{ID: "1", PRs: []int{1, 2}}}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "false"}, changes)
+	assert.Equal(t, 0, mgr.createOrUpdateCalled)
+}
+
+func TestRegisterNativeStack_SkippedWhenNotAvailableAndAuto(t *testing.T) {
+	mgr := &mockStackManager{available: false}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "auto"}, changes)
+	assert.Equal(t, 0, mgr.createOrUpdateCalled)
+}
+
+func TestRegisterNativeStack_CallsCreateOrUpdateWhenAvailable(t *testing.T) {
+	mgr := &mockStackManager{
+		available: true,
+		stack:     &api.Stack{ID: "42", PRs: []int{10, 20, 30}},
+	}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "10"}},
+		{pr: &api.PullRequest{ID: "20"}},
+		{pr: &api.PullRequest{ID: "30"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "auto"}, changes)
+	assert.Equal(t, 1, mgr.createOrUpdateCalled)
+	assert.Equal(t, []int{10, 20, 30}, mgr.lastPRNumbers)
+}
+
+func TestRegisterNativeStack_GracefulOnError(t *testing.T) {
+	mgr := &mockStackManager{
+		available: true,
+		err:       errors.New("API error"),
+	}
+	prAPI := &testAPIWithStack{stackMgr: mgr}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "true"}, changes)
+	assert.Equal(t, 1, mgr.createOrUpdateCalled)
+}
+
+func TestRegisterNativeStack_NilStackManagerWithAutoIsNoop(t *testing.T) {
+	prAPI := &testAPI{}
+	changes := []*change{
+		{pr: &api.PullRequest{ID: "1"}},
+		{pr: &api.PullRequest{ID: "2"}},
+	}
+	registerNativeStack(context.Background(), prAPI, ReviewOptions{Stack: "auto"}, changes)
 }
 
 func init() {


### PR DESCRIPTION
Problem
=====

The new StackManager implementation and registerNativeStack
integration point have no test coverage, making regressions hard to
catch.

Goal
=====

Verify that stack registration behaves correctly across all
configuration modes and error paths.

Solution
=====

Add tests for GitHubStackManager (availability probing, caching,
create/update, existing stack detection, API version header) and for
registerNativeStack (skipped when disabled, skipped when unavailable,
called when available, graceful on error, nil StackManager is a noop).
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
chore(deps): bump github.com/google/go-github from v55 to v90 (#2)
</summary>
Problem
=====

go-github v55 does not include the PullRequestStack types or the
WithVersion request option needed to call the GitHub Stacked PRs API
(version 2026-03-10).

Goal
=====

Upgrade to the latest go-github release to access native stack types
and the versioned request API required for stack management.

Solution
=====

Upgrade to go-github/v90 and adapt to breaking changes: NewClient now
uses functional options, CreatePullRequest replaces NewPullRequest,
BaseURL is a method returning string, and CreateCommit/CreateRef
signatures changed to value receivers.
</details>
<details>
<summary>
feat: add Stack option to ReviewOptions with git config support (#3)
</summary>
Problem
=====

There is no way to control whether Maiao should register PRs as a
GitHub native stack. The feature needs an opt-in mechanism that
defaults to automatic detection.

Goal
=====

Allow users to configure native stack behavior via git config without
requiring a CLI flag on every invocation.

Solution
=====

Add a Stack field to ReviewOptions populated from git config key
maiao.useNativeStack. Supports "auto" (default — probe and use if
available), "true" (require), and "false" (disable).
</details>
<details>
<summary>
feat: implement StackManager interface and GitHub client (#4)
</summary>
Problem
=====

Maiao creates PRs with proper base-branch chains but GitHub does not
recognize them as a native stack, so users miss the stack UI,
cascading rebases, and one-click merge-all.

Goal
=====

Provide a clean abstraction for managing GitHub native stacks that can
be called after PR creation and degrades gracefully on unsupported
instances.

Solution
=====

Define a StackManager interface (CreateOrUpdateStack, GetStack,
Available) and implement it using the GitHub REST API at
/repos/{owner}/{repo}/stacks with version header 2026-03-10. Expose
StackManager() on the PullRequester interface. Availability is probed
once and cached via sync.Once.
</details>
</details>
</details>