### PR TITLE
chore: migrate Homebrew formula and docs from adevinta to runetes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   call-build:
-    uses: adevinta/maiao/.github/workflows/go.yml@main
+    uses: runetes/maiao/.github/workflows/go.yml@main
 
   publish:
     runs-on: ubuntu-latest

--- a/HomebrewFormula/maiao.rb
+++ b/HomebrewFormula/maiao.rb
@@ -1,12 +1,12 @@
 class Maiao < Formula
   desc "Seamless GitHub PR management from the command-line"
-  homepage "https://github.com/adevinta/maiao"
-  url "https://github.com/adevinta/maiao.git",
+  homepage "https://github.com/runetes/maiao"
+  url "https://github.com/runetes/maiao.git",
     tag:      "1.2.2",
     revision: "94640a5700591f99ea1b4ed7afc43dc6510b4336"
   license "MIT"
   conflicts_with "git-review"
-  head "https://github.com/adevinta/maiao.git",
+  head "https://github.com/runetes/maiao.git",
     branch: "main"
 
   depends_on "go" => :build
@@ -14,7 +14,7 @@ class Maiao < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/adevinta/maiao/pkg/version.Version=#{version}+homebrew-adevinta-maiao
+      -X github.com/adevinta/maiao/pkg/version.Version=#{version}+homebrew-runetes-maiao
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags, output: bin/"git-review"), "./cmd/maiao"
@@ -22,6 +22,6 @@ class Maiao < Formula
   end
 
   test do
-    assert_match "#{version}+homebrew-adevinta-maiao", shell_output("#{bin}/git-review version")
+    assert_match "#{version}+homebrew-runetes-maiao", shell_output("#{bin}/git-review version")
   end
 end

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,13 +14,23 @@ Before installing Maiao, ensure you have:
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew tap adevinta/maiao https://github.com/adevinta/maiao.git
+brew tap runetes/maiao https://github.com/runetes/maiao.git
 brew install maiao
+```
+
+#### Migrating from adevinta/maiao
+
+If you previously installed maiao via `brew tap adevinta/maiao`, run:
+
+```bash
+brew untap adevinta/maiao
+brew tap runetes/maiao https://github.com/runetes/maiao.git
+brew reinstall maiao
 ```
 
 ### Binary Installation (Unix/Linux/macOS)
 
-1. Visit the [releases page](https://github.com/adevinta/maiao/releases)
+1. Visit the [releases page](https://github.com/runetes/maiao/releases)
 2. Download the appropriate binary for your system
 3. Install it:
 
@@ -35,7 +45,7 @@ xattr -d com.apple.quarantine /usr/local/bin/git-review
 
 ### Windows
 
-1. Visit the [releases page](https://github.com/adevinta/maiao/releases)
+1. Visit the [releases page](https://github.com/runetes/maiao/releases)
 2. Download `git-review-windows-<arch>` (usually `amd64`)
 3. Add to your PATH
 
@@ -252,14 +262,14 @@ Maiao groups all fixups by their target commit and updates PRs accordingly.
 To install maiao with homebrew, you need to tap the repo before installing it:
 
 ```bash
-brew tap adevinta/maiao https://github.com/adevinta/maiao.git
+brew tap runetes/maiao https://github.com/runetes/maiao.git
 brew install maiao
 ```
 
 ### Unix users
 
 The simplest way to install maiao is to download the binary from github. To do so, visit
-the [releases](https://github.com/adevinta/maiao/releases) page and download the version you want to install. Then run
+the [releases](https://github.com/runetes/maiao/releases) page and download the version you want to install. Then run
 
 ```
 mv <downloadsDir>/git-review-`uname -s`-`uname -m` /usr/local/bin/git-review
@@ -273,7 +283,7 @@ To build a standalone binary, you will need to run `go build -o /usr/local/bin/g
 
 ### Windows users
 
-The relevant Windows binary can be downloaded in the [releases](https://github.com/adevinta/maiao/releases) page
+The relevant Windows binary can be downloaded in the [releases](https://github.com/runetes/maiao/releases) page
 
 Download the `git-review-windows-<arch>` where `<arch>` is the architecture of your machine. If you are unsure, usually,
 amd64 is the default windows architecture.
@@ -300,7 +310,7 @@ To enable it, ensure you export the `MAIAO_EXPERIMENTAL_CREDENTIALS=true` enviro
 Maiao will then use your system keyring like [macOS keychain](https://support.apple.com/en-au/guide/keychain-access/welcome/mac) or [pass](https://www.passwordstore.org/)
 to store GitHub API keys.
 
-We will be happy to receive your feedback about this feature in [maiao's issues](https://github.com/adevinta/maiao/issues) 
+We will be happy to receive your feedback about this feature in [maiao's issues](https://github.com/runetes/maiao/issues) 
 
 
 Your environment is then ready to run maiao.
@@ -504,5 +514,5 @@ Don't amend commits directly; use fixups:
 ## 📚 Next Steps
 
 - **[How Does It Work](how-does-it-work.md)** - Deep dive into technical details
-- **[GitHub Issues](https://github.com/adevinta/maiao/issues)** - Report bugs or request features
+- **[GitHub Issues](https://github.com/runetes/maiao/issues)** - Report bugs or request features
 - **[Contributing](../CONTRIBUTING.md)** - Contribute to Maiao

--- a/docs/how-does-it-work.md
+++ b/docs/how-does-it-work.md
@@ -553,4 +553,4 @@ Change-IDs persist across:
 
 - **[Getting Started](getting-started.md)** - Installation and basic usage
 - **[Source Code](../pkg/maiao/review.go)** - Core implementation
-- **[GitHub Issues](https://github.com/adevinta/maiao/issues)** - Report bugs or request features
+- **[GitHub Issues](https://github.com/runetes/maiao/issues)** - Report bugs or request features


### PR DESCRIPTION
Problem
=======

All URLs, badges, and references still pointed to the old
adevinta/maiao repository which will become unmaintained.
Users who installed via `brew tap adevinta/maiao` have no
guidance on how to switch to the new tap.

Goal
====

Point the project's Homebrew formula, documentation, and CI
workflows to runetes/maiao and provide a clear migration path
for existing users.

Solution
========

- Update HomebrewFormula/maiao.rb URLs and version suffix to
  runetes/maiao.
- Update all release/issue links in docs to runetes/maiao.
- Add a "Migrating from adevinta/maiao" section in
  getting-started.md with untap/tap/reinstall instructions.
- Fix reusable workflow reference in release.yaml.
<details>
<summary>
Committer details
</summary>
Local-Branch: fork-cleanup
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
feat: automate releases with release-please and formula updates (#9)
</summary>
Problem
=======

Releasing a new version requires manually pushing a git tag and
then manually editing the Homebrew formula to update the tag and
revision fields. This means `brew upgrade maiao` stays stale
until someone remembers to update the formula.

Goal
====

Fully automated release pipeline: merge to main with conventional
commits → automatic versioning → build and publish → Homebrew
formula stays in sync without manual intervention.

Solution
========

- Add release-please workflow and configuration to automatically
  create release PRs based on conventional commits.
- Change release.yaml trigger from tag push to release published,
  so it fires after release-please creates the GitHub Release.
- Add an update-formula job to release.yaml that updates the
  tag and revision in HomebrewFormula/maiao.rb and pushes to
  main with [skip ci].
</details>
</details>
</details>