### PR TITLE
feat: add provider detection infrastructure for multi-provider support

### DIFF
--- a/pkg/api/pullRequester.go
+++ b/pkg/api/pullRequester.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/adevinta/maiao/pkg/log"
+	"github.com/adevinta/maiao/pkg/provider"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/sirupsen/logrus"
@@ -38,7 +40,7 @@ type PullRequest struct {
 	URL string
 }
 
-func NewPullRequester(ctx context.Context, remote *git.Remote) (PullRequester, error) {
+func NewPullRequester(ctx context.Context, remote *git.Remote, repoPath string) (PullRequester, error) {
 	for _, u := range remote.Config().URLs {
 		ctx := log.WithContextFields(ctx, logrus.Fields{"remote-url": u})
 		endpoint, err := transport.NewEndpoint(u)
@@ -46,12 +48,24 @@ func NewPullRequester(ctx context.Context, remote *git.Remote) (PullRequester, e
 			log.ForContext(ctx).WithError(err).Errorf("failed to parse remote")
 			continue
 		}
-		r, err := NewGitHubUpserter(ctx, endpoint)
+
+		providerType, err := provider.Detect(endpoint.Host, repoPath)
 		if err != nil {
-			log.ForContext(ctx).WithError(err).Errorf("failed to instanciate github client")
+			log.ForContext(ctx).WithError(err).Errorf("failed to detect provider")
 			continue
 		}
-		return r, nil
+
+		switch providerType {
+		case provider.GitHub:
+			r, err := NewGitHubUpserter(ctx, endpoint)
+			if err != nil {
+				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate github client")
+				continue
+			}
+			return r, nil
+		default:
+			return nil, fmt.Errorf("provider %q is not yet supported", providerType)
+		}
 	}
-	return nil, errors.New("not implemented")
+	return nil, errors.New("no supported provider found for remote")
 }

--- a/pkg/cmd/review.go
+++ b/pkg/cmd/review.go
@@ -43,6 +43,7 @@ func review(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return maiao.Review(context.Background(), repo, maiao.ReviewOptions{
+		RepoPath:       path,
 		Remote:         cmd.Flag("remote").Value.String(),
 		SkipRebase:     cmd.Flag("no-rebase").Value.String() != "false",
 		Topic:          cmd.Flag("topic").Value.String(),

--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -72,7 +72,7 @@ func Review(ctx context.Context, repo lgit.Repository, options ReviewOptions) er
 		return err
 	}
 
-	prAPI, err := api.NewPullRequester(ctx, remote)
+	prAPI, err := api.NewPullRequester(ctx, remote, options.RepoPath)
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func sendPrs(ctx context.Context, repo lgit.Repository, options ReviewOptions, b
 		return err
 	}
 
-	prAPI, err := api.NewPullRequester(ctx, remote)
+	prAPI, err := api.NewPullRequester(ctx, remote, options.RepoPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/prompt/select.go
+++ b/pkg/prompt/select.go
@@ -1,0 +1,15 @@
+package prompt
+
+import "github.com/manifoldco/promptui"
+
+// Select prompts the user to select an item from a list and returns the selected index.
+func Select(label string, items []string) (int, error) {
+	p := promptui.Select{
+		Label:  label,
+		Items:  items,
+		Stdin:  stdin,
+		Stdout: stdout,
+	}
+	idx, _, err := p.Run()
+	return idx, err
+}

--- a/pkg/prompt/select_test.go
+++ b/pkg/prompt/select_test.go
@@ -1,0 +1,52 @@
+package prompt
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectOutputContainsItems(t *testing.T) {
+	defer setStdInOut(stdin, stdout)
+	inr, inw, _ := os.Pipe()
+	outr, outw, _ := os.Pipe()
+	setStdInOut(inr, outw)
+
+	items := []string{"gitlab", "github", "gitea"}
+	done := make(chan int)
+	go func() {
+		idx, _ := Select("Which provider?", items)
+		done <- idx
+	}()
+
+	q := make([]byte, 1024)
+	for c := 0; c < 10; c, _ = outr.Read(q) {
+	}
+	output := string(q)
+	assert.Contains(t, output, "Which provider?")
+
+	// Send enter to select first item
+	inw.Write([]byte("\n"))
+	idx := <-done
+	assert.Equal(t, 0, idx)
+}
+
+func TestSelectReturnsSelectedIndex(t *testing.T) {
+	defer setStdInOut(stdin, stdout)
+	inr, inw, _ := os.Pipe()
+	_, outw, _ := os.Pipe()
+	setStdInOut(inr, outw)
+
+	items := []string{"gitlab", "github", "gitea"}
+	done := make(chan int)
+	go func() {
+		idx, _ := Select("Which provider?", items)
+		done <- idx
+	}()
+
+	// Move down once and select (arrow down = \x1b[B, enter = \n)
+	inw.Write([]byte("\x1b[B\n"))
+	idx := <-done
+	assert.Equal(t, 1, idx)
+}

--- a/pkg/provider/detect.go
+++ b/pkg/provider/detect.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/prompt"
+)
+
+func Detect(host string, repoPath string) (Type, error) {
+	if t, ok := KnownHosts[host]; ok {
+		return t, nil
+	}
+
+	t, err := readProviderFromConfig(repoPath)
+	if err == nil {
+		return t, nil
+	}
+
+	t, err = promptForProvider(host)
+	if err != nil {
+		return "", err
+	}
+
+	writeProviderToConfig(repoPath, t)
+	return t, nil
+}
+
+func readProviderFromConfig(repoPath string) (Type, error) {
+	cmd := exec.Command("git", "config", "--local", "maiao.provider")
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	val := strings.TrimSpace(string(out))
+	t, ok := ParseType(val)
+	if !ok {
+		return "", fmt.Errorf("unknown provider type: %s", val)
+	}
+	return t, nil
+}
+
+func writeProviderToConfig(repoPath string, t Type) {
+	cmd := exec.Command("git", "config", "--local", "maiao.provider", string(t))
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	cmd.Run()
+}
+
+func promptForProvider(host string) (Type, error) {
+	items := []string{
+		string(GitLab),
+		string(GitHub),
+		string(Gitea),
+		string(Forgejo),
+		string(Bitbucket),
+	}
+	label := fmt.Sprintf("Detected remote host: %s. Which provider is this?", host)
+	idx, err := prompt.Select(label, items)
+	if err != nil {
+		return "", err
+	}
+	t, _ := ParseType(items[idx])
+	return t, nil
+}

--- a/pkg/provider/detect.go
+++ b/pkg/provider/detect.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/adevinta/maiao/pkg/prompt"
+	"github.com/sirupsen/logrus"
 )
 
 func Detect(host string, repoPath string) (Type, error) {
@@ -23,7 +24,9 @@ func Detect(host string, repoPath string) (Type, error) {
 		return "", err
 	}
 
-	writeProviderToConfig(repoPath, t)
+	if err := writeProviderToConfig(repoPath, t); err != nil {
+		logrus.WithError(err).Warn("failed to save provider to git config")
+	}
 	return t, nil
 }
 
@@ -44,12 +47,12 @@ func readProviderFromConfig(repoPath string) (Type, error) {
 	return t, nil
 }
 
-func writeProviderToConfig(repoPath string, t Type) {
+func writeProviderToConfig(repoPath string, t Type) error {
 	cmd := exec.Command("git", "config", "--local", "maiao.provider", string(t))
 	if repoPath != "" {
 		cmd.Dir = repoPath
 	}
-	cmd.Run()
+	return cmd.Run()
 }
 
 func promptForProvider(host string) (Type, error) {

--- a/pkg/provider/detect_test.go
+++ b/pkg/provider/detect_test.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+	// git requires user config for some operations
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = dir
+	cmd.Run()
+	cmd = exec.Command("git", "config", "user.name", "Test")
+	cmd.Dir = dir
+	cmd.Run()
+	return dir
+}
+
+func TestDetectKnownHosts(t *testing.T) {
+	tests := []struct {
+		host     string
+		expected Type
+	}{
+		{"github.com", GitHub},
+		{"gitlab.com", GitLab},
+		{"codeberg.org", Forgejo},
+		{"bitbucket.org", Bitbucket},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			result, err := Detect(tt.host, "")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectReadsFromGitConfig(t *testing.T) {
+	dir := initTestRepo(t)
+
+	cmd := exec.Command("git", "config", "--local", "maiao.provider", "gitlab")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+
+	result, err := Detect("git.company.com", dir)
+	assert.NoError(t, err)
+	assert.Equal(t, GitLab, result)
+}
+
+func TestDetectIgnoresInvalidGitConfigValue(t *testing.T) {
+	dir := initTestRepo(t)
+
+	cmd := exec.Command("git", "config", "--local", "maiao.provider", "invalid-provider")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+
+	// Should fall through to prompt since config value is invalid.
+	// Since we can't easily mock the prompt in this package, we test
+	// readProviderFromConfig directly.
+	_, err := readProviderFromConfig(dir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown provider type")
+}
+
+func TestReadProviderFromConfigNoConfig(t *testing.T) {
+	dir := initTestRepo(t)
+	_, err := readProviderFromConfig(dir)
+	assert.Error(t, err)
+}
+
+func TestReadProviderFromConfigValidValues(t *testing.T) {
+	for _, pt := range AllTypes {
+		t.Run(string(pt), func(t *testing.T) {
+			dir := initTestRepo(t)
+			cmd := exec.Command("git", "config", "--local", "maiao.provider", string(pt))
+			cmd.Dir = dir
+			require.NoError(t, cmd.Run())
+
+			result, err := readProviderFromConfig(dir)
+			assert.NoError(t, err)
+			assert.Equal(t, pt, result)
+		})
+	}
+}
+
+func TestWriteProviderToConfig(t *testing.T) {
+	dir := initTestRepo(t)
+	writeProviderToConfig(dir, GitLab)
+
+	cmd := exec.Command("git", "config", "--local", "maiao.provider")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	assert.Equal(t, "gitlab\n", string(out))
+}
+
+func TestWriteProviderToConfigUpdatesExisting(t *testing.T) {
+	dir := initTestRepo(t)
+	writeProviderToConfig(dir, GitLab)
+	writeProviderToConfig(dir, Gitea)
+
+	cmd := exec.Command("git", "config", "--local", "maiao.provider")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	assert.Equal(t, "gitea\n", string(out))
+}
+
+func TestDetectKnownHostTakesPrecedenceOverConfig(t *testing.T) {
+	dir := initTestRepo(t)
+
+	cmd := exec.Command("git", "config", "--local", "maiao.provider", "bitbucket")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+
+	// github.com is a known host and should take precedence
+	result, err := Detect("github.com", dir)
+	assert.NoError(t, err)
+	assert.Equal(t, GitHub, result)
+}
+
+func TestDetectWithEmptyRepoPath(t *testing.T) {
+	// For known hosts, empty repoPath should still work
+	result, err := Detect("gitlab.com", "")
+	assert.NoError(t, err)
+	assert.Equal(t, GitLab, result)
+}
+
+func TestDetectWithNonExistentPath(t *testing.T) {
+	// Unknown host + non-existent path should fail (can't read config, can't prompt in test)
+	nonExistent := filepath.Join(os.TempDir(), "non-existent-repo-path-12345")
+	_, err := Detect("git.company.com", nonExistent)
+	assert.Error(t, err)
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,0 +1,33 @@
+package provider
+
+type Type string
+
+const (
+	GitHub    Type = "github"
+	GitLab    Type = "gitlab"
+	Gitea     Type = "gitea"
+	Forgejo   Type = "forgejo"
+	Bitbucket Type = "bitbucket"
+)
+
+var KnownHosts = map[string]Type{
+	"github.com":    GitHub,
+	"gitlab.com":    GitLab,
+	"codeberg.org":  Forgejo,
+	"bitbucket.org": Bitbucket,
+}
+
+var AllTypes = []Type{GitHub, GitLab, Gitea, Forgejo, Bitbucket}
+
+func (t Type) String() string {
+	return string(t)
+}
+
+func ParseType(s string) (Type, bool) {
+	switch Type(s) {
+	case GitHub, GitLab, Gitea, Forgejo, Bitbucket:
+		return Type(s), true
+	default:
+		return "", false
+	}
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTypeValid(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected Type
+	}{
+		{"github", GitHub},
+		{"gitlab", GitLab},
+		{"gitea", Gitea},
+		{"forgejo", Forgejo},
+		{"bitbucket", Bitbucket},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, ok := ParseType(tt.input)
+			assert.True(t, ok)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseTypeInvalid(t *testing.T) {
+	tests := []string{"", "unknown", "GitHub", "GITLAB", "gerrit"}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, ok := ParseType(input)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestTypeString(t *testing.T) {
+	assert.Equal(t, "github", GitHub.String())
+	assert.Equal(t, "gitlab", GitLab.String())
+	assert.Equal(t, "gitea", Gitea.String())
+	assert.Equal(t, "forgejo", Forgejo.String())
+	assert.Equal(t, "bitbucket", Bitbucket.String())
+}
+
+func TestKnownHostsContainsExpectedEntries(t *testing.T) {
+	assert.Equal(t, GitHub, KnownHosts["github.com"])
+	assert.Equal(t, GitLab, KnownHosts["gitlab.com"])
+	assert.Equal(t, Forgejo, KnownHosts["codeberg.org"])
+	assert.Equal(t, Bitbucket, KnownHosts["bitbucket.org"])
+}


### PR DESCRIPTION
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
feat: add provider-aware credential resolution (<a href="https://github.com/runetes/maiao/pull/13">#13</a>)
</summary>
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
</details>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
<details>
<summary>
feat: add Gitea pull request support (<a href="https://github.com/runetes/maiao/pull/15">#15</a>)
</summary>
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
</details>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
<details>
<summary>
feat: add Bitbucket Cloud pull request support (<a href="https://github.com/runetes/maiao/pull/17">#17</a>)
</summary>
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
</details>
<details>
<summary>
fix: auto-resolve SSH known_hosts errors with interactive prompt (<a href="https://github.com/runetes/maiao/pull/18">#18</a>)
</summary>
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
</details>
<details>
<summary>
docs: update documentation for multi-provider support (<a href="https://github.com/runetes/maiao/pull/19">#19</a>)
</summary>
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
</details>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
<details>
<summary>
fix: surface actual error when provider client creation fails (<a href="https://github.com/runetes/maiao/pull/21">#21</a>)
</summary>
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
</details>
<details>
<summary>
feat: add Cursor Origin provider support (beta) (<a href="https://github.com/runetes/maiao/pull/23">#23</a>)
</summary>
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
</details>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>