### PR TITLE
[need #12] feat: add provider-aware credential resolution

### DIFF
--- a/pkg/credentials/provider.go
+++ b/pkg/credentials/provider.go
@@ -1,0 +1,35 @@
+package credentials
+
+import (
+	"github.com/99designs/keyring"
+)
+
+var envVarForProvider = map[string]string{
+	"github":    "GITHUB_TOKEN",
+	"gitlab":    "GITLAB_TOKEN",
+	"gitea":     "GITEA_TOKEN",
+	"forgejo":   "FORGEJO_TOKEN",
+	"bitbucket": "BITBUCKET_TOKEN",
+}
+
+func CredentialGetterForProvider(providerType string) CredentialGetter {
+	envKey := envVarForProvider[providerType]
+	if envKey == "" {
+		envKey = "GITHUB_TOKEN"
+	}
+
+	getters := []CredentialGetter{
+		&EnvToken{PasswordKey: envKey},
+		&Netrc{},
+		&GitCredentials{GitPath: "git"},
+	}
+
+	kr, err := NewKeyring(keyring.Config{
+		ServiceName: "maiao",
+	})
+	if err == nil {
+		getters = append(getters, kr)
+	}
+
+	return ChainCredentialGetter(getters)
+}

--- a/pkg/credentials/provider_test.go
+++ b/pkg/credentials/provider_test.go
@@ -1,0 +1,57 @@
+package credentials
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialGetterForProviderUsesCorrectEnvVar(t *testing.T) {
+	tests := []struct {
+		provider string
+		envKey   string
+	}{
+		{"github", "GITHUB_TOKEN"},
+		{"gitlab", "GITLAB_TOKEN"},
+		{"gitea", "GITEA_TOKEN"},
+		{"forgejo", "FORGEJO_TOKEN"},
+		{"bitbucket", "BITBUCKET_TOKEN"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			old := os.Getenv(tt.envKey)
+			defer os.Setenv(tt.envKey, old)
+			os.Setenv(tt.envKey, "test-token-"+tt.provider)
+
+			getter := CredentialGetterForProvider(tt.provider)
+			cred, err := getter.CredentialForHost("any-host.example.com")
+			require.NoError(t, err)
+			assert.Equal(t, "test-token-"+tt.provider, cred.Password)
+			assert.Equal(t, "x-token", cred.Username)
+		})
+	}
+}
+
+func TestCredentialGetterForProviderFallsBackToGitHubForUnknown(t *testing.T) {
+	old := os.Getenv("GITHUB_TOKEN")
+	defer os.Setenv("GITHUB_TOKEN", old)
+	os.Setenv("GITHUB_TOKEN", "fallback-token")
+
+	getter := CredentialGetterForProvider("unknown")
+	cred, err := getter.CredentialForHost("any-host.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "fallback-token", cred.Password)
+}
+
+func TestCredentialGetterForProviderReturnsErrorWhenNoCredentials(t *testing.T) {
+	// Ensure env var is unset
+	old := os.Getenv("GITLAB_TOKEN")
+	defer os.Setenv("GITLAB_TOKEN", old)
+	os.Unsetenv("GITLAB_TOKEN")
+
+	getter := CredentialGetterForProvider("gitlab")
+	_, err := getter.CredentialForHost("non-existent-host-in-netrc.example.com")
+	assert.Error(t, err)
+}

--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -12,8 +12,8 @@ import (
 	"github.com/adevinta/maiao/pkg/api"
 	"github.com/adevinta/maiao/pkg/credentials"
 	lgit "github.com/adevinta/maiao/pkg/git"
-	gh "github.com/adevinta/maiao/pkg/github"
 	"github.com/adevinta/maiao/pkg/log"
+	"github.com/adevinta/maiao/pkg/provider"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -92,10 +92,16 @@ func Review(ctx context.Context, repo lgit.Repository, options ReviewOptions) er
 		return err
 	}
 
+	providerType, err := provider.Detect(endpoint.Host, options.RepoPath)
+	if err != nil {
+		return err
+	}
+	credGetter := credentials.CredentialGetterForProvider(string(providerType))
+
 	log.ForContext(ctx).Debugf("fetching remote")
 	err = remote.Fetch(&git.FetchOptions{
 		RemoteName: options.Remote,
-		Auth:       &credentials.GitAuth{Credentials: gh.DefaultCredentialGetter, Endpoint: endpoint},
+		Auth:       &credentials.GitAuth{Credentials: credGetter, Endpoint: endpoint},
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		log.ForContext(ctx).WithError(err).Error("failed to update git repository")
@@ -249,11 +255,17 @@ func sendPrs(ctx context.Context, repo lgit.Repository, options ReviewOptions, b
 		return err
 	}
 
+	providerType, err := provider.Detect(endpoint.Host, options.RepoPath)
+	if err != nil {
+		return err
+	}
+	credGetter := credentials.CredentialGetterForProvider(string(providerType))
+
 	log.ForContext(ctx).WithField("refspec", refspecs).Debugf("pushing PR changes")
 	err = repo.Push(&git.PushOptions{
 		RemoteName: options.Remote,
 		RefSpecs:   refspecs,
-		Auth:       &credentials.GitAuth{Credentials: gh.DefaultCredentialGetter, Endpoint: endpoint},
+		Auth:       &credentials.GitAuth{Credentials: credGetter, Endpoint: endpoint},
 		Force:      true,
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {


### PR DESCRIPTION
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
feat: add provider detection infrastructure for multi-provider support (<a href="https://github.com/runetes/maiao/pull/12">#12</a>)
</summary>
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
<details>
<summary>
feat: add Gitea pull request support (<a href="https://github.com/runetes/maiao/pull/15">#15</a>)
</summary>
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
</details>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
<details>
<summary>
feat: add Bitbucket Cloud pull request support (<a href="https://github.com/runetes/maiao/pull/17">#17</a>)
</summary>
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
</details>
<details>
<summary>
fix: auto-resolve SSH known_hosts errors with interactive prompt (<a href="https://github.com/runetes/maiao/pull/18">#18</a>)
</summary>
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
</details>
<details>
<summary>
docs: update documentation for multi-provider support (<a href="https://github.com/runetes/maiao/pull/19">#19</a>)
</summary>
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
</details>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
<details>
<summary>
fix: surface actual error when provider client creation fails (<a href="https://github.com/runetes/maiao/pull/21">#21</a>)
</summary>
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
</details>
<details>
<summary>
feat: add Cursor Origin provider support (beta) (<a href="https://github.com/runetes/maiao/pull/23">#23</a>)
</summary>
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
</details>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>