### PR TITLE
[need #14] feat: add Gitea pull request support

### DIFF
--- a/pkg/gitea/base.go
+++ b/pkg/gitea/base.go
@@ -1,0 +1,217 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/api"
+	"github.com/adevinta/maiao/pkg/log"
+)
+
+type BaseClient struct {
+	Host       string
+	Owner      string
+	Repository string
+	HTTPClient *http.Client
+	APIBase    string
+}
+
+type pullRequest struct {
+	ID     int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+}
+
+type repository struct {
+	DefaultBranch string `json:"default_branch"`
+}
+
+func (b *BaseClient) Ensure(ctx context.Context, options api.PullRequestOptions) (*api.PullRequest, bool, error) {
+	prs, err := b.listPRs(ctx, options.Head)
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch len(prs) {
+	case 0:
+		pr, err := b.createPR(ctx, options)
+		if err != nil {
+			return nil, false, err
+		}
+		return &api.PullRequest{
+			ID:  fmt.Sprintf("%d", pr.ID),
+			URL: pr.HTMLURL,
+		}, true, nil
+	case 1:
+		return &api.PullRequest{
+			ID:  fmt.Sprintf("%d", prs[0].ID),
+			URL: prs[0].HTMLURL,
+		}, false, nil
+	default:
+		return nil, false, fmt.Errorf("too many matching pull requests (%d)", len(prs))
+	}
+}
+
+func (b *BaseClient) Update(ctx context.Context, pr *api.PullRequest, options api.PullRequestOptions) (*api.PullRequest, error) {
+	title := options.Title
+	if options.WIP && !strings.HasPrefix(title, "WIP: ") {
+		title = "WIP: " + title
+	}
+	if options.Ready && strings.HasPrefix(title, "WIP: ") {
+		title = strings.TrimPrefix(title, "WIP: ")
+	}
+
+	body := map[string]interface{}{
+		"title": title,
+		"body":  options.Body,
+		"base":  options.Base,
+	}
+
+	reqURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%s", b.APIBase, b.Owner, b.Repository, pr.ID)
+	resp, err := b.doJSON(ctx, http.MethodPatch, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to update pull request: %s %s", resp.Status, string(respBody))
+	}
+
+	var result pullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return &api.PullRequest{
+		ID:  fmt.Sprintf("%d", result.ID),
+		URL: result.HTMLURL,
+	}, nil
+}
+
+func (b *BaseClient) DefaultBranch(ctx context.Context) string {
+	reqURL := fmt.Sprintf("%s/repos/%s/%s", b.APIBase, b.Owner, b.Repository)
+	resp, err := b.doRequest(ctx, http.MethodGet, reqURL)
+	if err != nil {
+		log.ForContext(ctx).WithError(err).Error("failed to get repository info")
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var r repository
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return ""
+	}
+	return r.DefaultBranch
+}
+
+func (b *BaseClient) LinkedTopicIssues(topicSearchString string) string {
+	values := url.Values{}
+	values.Add("q", topicSearchString)
+	values.Add("type", "pulls")
+	values.Add("state", "open")
+	return fmt.Sprintf("https://%s/%s/%s/pulls?%s", b.Host, b.Owner, b.Repository, values.Encode())
+}
+
+func (b *BaseClient) StackManager() api.StackManager {
+	return nil
+}
+
+func (b *BaseClient) listPRs(ctx context.Context, head string) ([]pullRequest, error) {
+	params := url.Values{}
+	params.Add("state", "open")
+	reqURL := fmt.Sprintf("%s/repos/%s/%s/pulls?%s", b.APIBase, b.Owner, b.Repository, params.Encode())
+
+	resp, err := b.doRequest(ctx, http.MethodGet, reqURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to list pull requests: %s %s", resp.Status, string(respBody))
+	}
+
+	var allPRs []struct {
+		pullRequest
+		Head struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&allPRs); err != nil {
+		return nil, err
+	}
+
+	var matching []pullRequest
+	for _, pr := range allPRs {
+		if pr.Head.Ref == head {
+			matching = append(matching, pr.pullRequest)
+		}
+	}
+	return matching, nil
+}
+
+func (b *BaseClient) createPR(ctx context.Context, options api.PullRequestOptions) (*pullRequest, error) {
+	title := options.Title
+	if options.WIP {
+		title = "WIP: " + title
+	}
+
+	body := map[string]interface{}{
+		"head":  options.Head,
+		"base":  options.Base,
+		"title": title,
+		"body":  options.Body,
+	}
+
+	reqURL := fmt.Sprintf("%s/repos/%s/%s/pulls", b.APIBase, b.Owner, b.Repository)
+	resp, err := b.doJSON(ctx, http.MethodPost, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to create pull request: %s %s", resp.Status, string(respBody))
+	}
+
+	var pr pullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+func (b *BaseClient) doJSON(ctx context.Context, method, reqURL string, body interface{}) (*http.Response, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return b.HTTPClient.Do(req)
+}
+
+func (b *BaseClient) doRequest(ctx context.Context, method, reqURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return b.HTTPClient.Do(req)
+}

--- a/pkg/gitea/gitea.go
+++ b/pkg/gitea/gitea.go
@@ -1,0 +1,60 @@
+package gitea
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/credentials"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+type Gitea struct {
+	BaseClient
+}
+
+func NewGiteaUpserter(ctx context.Context, endpoint *transport.Endpoint) (*Gitea, error) {
+	orgRepo := strings.Split(strings.Trim(endpoint.Path, "/"), "/")
+	if len(orgRepo) != 2 {
+		return nil, fmt.Errorf("invalid repository path: %s (expected owner/repo)", endpoint.Path)
+	}
+
+	owner := orgRepo[0]
+	repo := strings.TrimSuffix(orgRepo[1], ".git")
+
+	credGetter := credentials.CredentialGetterForProvider("gitea")
+	cred, err := credGetter.CredentialForHost(endpoint.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credentials for %s: %w", endpoint.Host, err)
+	}
+
+	apiBase := fmt.Sprintf("https://%s/api/v1", endpoint.Host)
+
+	client := &http.Client{
+		Transport: &tokenTransport{
+			token:    cred.Password,
+			delegate: http.DefaultTransport,
+		},
+	}
+
+	return &Gitea{
+		BaseClient: BaseClient{
+			Host:       endpoint.Host,
+			Owner:      owner,
+			Repository: repo,
+			HTTPClient: client,
+			APIBase:    apiBase,
+		},
+	}, nil
+}
+
+type tokenTransport struct {
+	token    string
+	delegate http.RoundTripper
+}
+
+func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", "token "+t.token)
+	return t.delegate.RoundTrip(req)
+}

--- a/pkg/gitea/gitea_test.go
+++ b/pkg/gitea/gitea_test.go
@@ -1,0 +1,294 @@
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/adevinta/maiao/pkg/api"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripperFunc func(r *http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+func newTestBaseClient(rt http.RoundTripper) *BaseClient {
+	return &BaseClient{
+		Host:       "gitea.example.com",
+		Owner:      "owner",
+		Repository: "repo",
+		HTTPClient: &http.Client{Transport: rt},
+		APIBase:    "https://gitea.example.com/api/v1",
+	}
+}
+
+func TestEnsureReturnsExistingPR(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := `[{"number": 42, "html_url": "https://gitea.example.com/owner/repo/pulls/42", "state": "open", "head": {"ref": "maiao.abc123"}}]`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, created, err := b.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	require.NoError(t, err)
+	assert.False(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "42", pr.ID)
+	assert.Equal(t, "https://gitea.example.com/owner/repo/pulls/42", pr.URL)
+}
+
+func TestEnsureCreatesNewPR(t *testing.T) {
+	callCount := 0
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		callCount++
+		switch r.Method {
+		case http.MethodGet:
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("[]"))}, nil
+		case http.MethodPost:
+			var reqBody map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&reqBody)
+			assert.Equal(t, "maiao.abc123", reqBody["head"])
+			assert.Equal(t, "main", reqBody["base"])
+			assert.Equal(t, "Test PR", reqBody["title"])
+			body := `{"number": 99, "html_url": "https://gitea.example.com/owner/repo/pulls/99"}`
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(body))}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	}))
+
+	pr, created, err := b.Ensure(context.Background(), api.PullRequestOptions{
+		Head:  "maiao.abc123",
+		Base:  "main",
+		Title: "Test PR",
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "99", pr.ID)
+}
+
+func TestEnsureWithWIPCreatesWIPPR(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method == http.MethodGet {
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("[]"))}, nil
+		}
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.Equal(t, "WIP: Test PR", reqBody["title"])
+		body := `{"number": 100, "html_url": "url"}`
+		return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	_, _, err := b.Ensure(context.Background(), api.PullRequestOptions{
+		Head:  "maiao.abc123",
+		Base:  "main",
+		Title: "Test PR",
+		WIP:   true,
+	})
+	require.NoError(t, err)
+}
+
+func TestEnsureReturnsErrorWhenTooManyPRs(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := `[
+			{"number": 1, "html_url": "url1", "head": {"ref": "maiao.abc123"}},
+			{"number": 2, "html_url": "url2", "head": {"ref": "maiao.abc123"}}
+		]`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, _, err := b.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	assert.Nil(t, pr)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many matching pull requests")
+}
+
+func TestEnsureFiltersbyHead(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := `[
+			{"number": 1, "html_url": "url1", "head": {"ref": "maiao.abc123"}},
+			{"number": 2, "html_url": "url2", "head": {"ref": "maiao.other"}}
+		]`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, created, err := b.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	require.NoError(t, err)
+	assert.False(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "1", pr.ID)
+}
+
+func TestEnsureReturnsErrorOnAPIFailure(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("error"))}, nil
+	}))
+
+	pr, _, err := b.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	assert.Nil(t, pr)
+	assert.Error(t, err)
+}
+
+func TestUpdatePR(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Contains(t, r.URL.Path, "/pulls/42")
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.Equal(t, "Updated Title", reqBody["title"])
+		assert.Equal(t, "Updated Body", reqBody["body"])
+		assert.Equal(t, "develop", reqBody["base"])
+		body := `{"number": 42, "html_url": "https://gitea.example.com/owner/repo/pulls/42"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, err := b.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "Updated Title",
+		Body:  "Updated Body",
+		Base:  "develop",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	assert.Equal(t, "42", pr.ID)
+}
+
+func TestUpdatePRAddsWIPPrefix(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.Equal(t, "WIP: My Feature", reqBody["title"])
+		body := `{"number": 42, "html_url": "url"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	_, err := b.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "My Feature",
+		Base:  "main",
+		WIP:   true,
+	})
+	require.NoError(t, err)
+}
+
+func TestUpdatePRRemovesWIPPrefix(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.Equal(t, "My Feature", reqBody["title"])
+		body := `{"number": 42, "html_url": "url"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	_, err := b.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "WIP: My Feature",
+		Base:  "main",
+		Ready: true,
+	})
+	require.NoError(t, err)
+}
+
+func TestUpdateReturnsErrorOnAPIFailure(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader("forbidden"))}, nil
+	}))
+
+	_, err := b.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "Title",
+		Base:  "main",
+	})
+	assert.Error(t, err)
+}
+
+func TestDefaultBranch(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/owner/repo")
+		body := `{"default_branch": "main"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	branch := b.DefaultBranch(context.Background())
+	assert.Equal(t, "main", branch)
+}
+
+func TestDefaultBranchReturnsEmptyOnError(t *testing.T) {
+	b := newTestBaseClient(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}))
+
+	branch := b.DefaultBranch(context.Background())
+	assert.Equal(t, "", branch)
+}
+
+func TestLinkedTopicIssues(t *testing.T) {
+	b := &BaseClient{Host: "gitea.example.com", Owner: "owner", Repository: "repo"}
+	result := b.LinkedTopicIssues("topic-sha")
+	assert.Contains(t, result, "gitea.example.com/owner/repo/pulls")
+	assert.Contains(t, result, "q=topic-sha")
+	assert.Contains(t, result, "state=open")
+}
+
+func TestStackManagerReturnsNil(t *testing.T) {
+	b := &BaseClient{}
+	assert.Nil(t, b.StackManager())
+}
+
+func TestNewGiteaUpserterInvalidPath(t *testing.T) {
+	g, err := NewGiteaUpserter(context.Background(), &transport.Endpoint{Host: "gitea.example.com", Path: "invalid"})
+	assert.Error(t, err)
+	assert.Nil(t, g)
+}
+
+func TestNewGiteaUpserterNestedPath(t *testing.T) {
+	g, err := NewGiteaUpserter(context.Background(), &transport.Endpoint{Host: "gitea.example.com", Path: "/group/subgroup/repo"})
+	assert.Error(t, err)
+	assert.Nil(t, g)
+}
+
+func TestNewGiteaUpserterValidPath(t *testing.T) {
+	old := os.Getenv("GITEA_TOKEN")
+	defer os.Setenv("GITEA_TOKEN", old)
+	os.Setenv("GITEA_TOKEN", "test-token")
+
+	g, err := NewGiteaUpserter(context.Background(), &transport.Endpoint{Host: "gitea.example.com", Path: "/owner/repo.git"})
+	require.NoError(t, err)
+	require.NotNil(t, g)
+	assert.Equal(t, "gitea.example.com", g.Host)
+	assert.Equal(t, "owner", g.Owner)
+	assert.Equal(t, "repo", g.Repository)
+	assert.Equal(t, "https://gitea.example.com/api/v1", g.APIBase)
+}
+
+func TestNewGiteaUpserterNoCredentials(t *testing.T) {
+	old := os.Getenv("GITEA_TOKEN")
+	defer os.Setenv("GITEA_TOKEN", old)
+	os.Unsetenv("GITEA_TOKEN")
+
+	g, err := NewGiteaUpserter(context.Background(), &transport.Endpoint{Host: "no-cred-host.example.com", Path: "/owner/repo"})
+	assert.Error(t, err)
+	assert.Nil(t, g)
+}
+
+func TestTokenTransportSetsHeader(t *testing.T) {
+	var capturedHeader string
+	transport := &tokenTransport{
+		token: "my-secret-token",
+		delegate: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			capturedHeader = r.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://gitea.example.com/api/v1/repos", nil)
+	transport.RoundTrip(req)
+	assert.Equal(t, "token my-secret-token", capturedHeader)
+}

--- a/pkg/maiao/factory.go
+++ b/pkg/maiao/factory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/adevinta/maiao/pkg/api"
+	"github.com/adevinta/maiao/pkg/gitea"
 	"github.com/adevinta/maiao/pkg/gitlab"
 	"github.com/adevinta/maiao/pkg/log"
 	"github.com/adevinta/maiao/pkg/provider"
@@ -41,6 +42,13 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := gitlab.NewGitLabUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate gitlab client")
+				continue
+			}
+			return r, nil
+		case provider.Gitea:
+			r, err := gitea.NewGiteaUpserter(ctx, endpoint)
+			if err != nil {
+				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate gitea client")
 				continue
 			}
 			return r, nil


### PR DESCRIPTION
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
feat: add provider detection infrastructure for multi-provider support (<a href="https://github.com/runetes/maiao/pull/12">#12</a>)
</summary>
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
</details>
<details>
<summary>
feat: add provider-aware credential resolution (<a href="https://github.com/runetes/maiao/pull/13">#13</a>)
</summary>
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
</details>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
<details>
<summary>
feat: add Bitbucket Cloud pull request support (<a href="https://github.com/runetes/maiao/pull/17">#17</a>)
</summary>
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
</details>
<details>
<summary>
fix: auto-resolve SSH known_hosts errors with interactive prompt (<a href="https://github.com/runetes/maiao/pull/18">#18</a>)
</summary>
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
</details>
<details>
<summary>
docs: update documentation for multi-provider support (<a href="https://github.com/runetes/maiao/pull/19">#19</a>)
</summary>
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
</details>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
<details>
<summary>
fix: surface actual error when provider client creation fails (<a href="https://github.com/runetes/maiao/pull/21">#21</a>)
</summary>
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
</details>
<details>
<summary>
feat: add Cursor Origin provider support (beta) (<a href="https://github.com/runetes/maiao/pull/23">#23</a>)
</summary>
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
</details>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>