### PR TITLE
[need #16] feat: add Bitbucket Cloud pull request support

### DIFF
--- a/pkg/api/formatter.go
+++ b/pkg/api/formatter.go
@@ -1,0 +1,29 @@
+package api
+
+// BodyFormatter controls how PR body sections (committer details, related changes, topics) are rendered.
+type BodyFormatter interface {
+	Section(title string, content []string) []string
+	Link(url, text string) string
+	LineBreak() string
+}
+
+// HTMLBodyFormatter renders sections as collapsible <details> blocks.
+type HTMLBodyFormatter struct{}
+
+func (HTMLBodyFormatter) Section(title string, content []string) []string {
+	r := []string{"<details>"}
+	if title != "" {
+		r = append(r, "<summary>", title, "</summary>")
+	}
+	r = append(r, content...)
+	r = append(r, "</details>")
+	return r
+}
+
+func (HTMLBodyFormatter) Link(url, text string) string {
+	return `<a href="` + url + `">` + text + `</a>`
+}
+
+func (HTMLBodyFormatter) LineBreak() string {
+	return "<br/>"
+}

--- a/pkg/api/formatter_test.go
+++ b/pkg/api/formatter_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTMLFormatterSectionWithTitle(t *testing.T) {
+	f := HTMLBodyFormatter{}
+	result := f.Section("summary", []string{"hello world"})
+	assert.Equal(t, []string{
+		"<details>",
+		"<summary>",
+		"summary",
+		"</summary>",
+		"hello world",
+		"</details>",
+	}, result)
+}
+
+func TestHTMLFormatterSectionWithoutTitle(t *testing.T) {
+	f := HTMLBodyFormatter{}
+	result := f.Section("", []string{"hello world"})
+	assert.Equal(t, []string{
+		"<details>",
+		"hello world",
+		"</details>",
+	}, result)
+}
+
+func TestHTMLFormatterLink(t *testing.T) {
+	f := HTMLBodyFormatter{}
+	assert.Equal(t, `<a href="https://example.com">my link</a>`, f.Link("https://example.com", "my link"))
+}
+
+func TestHTMLFormatterLineBreak(t *testing.T) {
+	f := HTMLBodyFormatter{}
+	assert.Equal(t, "<br/>", f.LineBreak())
+}

--- a/pkg/api/github.go
+++ b/pkg/api/github.go
@@ -174,6 +174,10 @@ func (g *GitHub) StackManager() StackManager {
 	return g.stackManager
 }
 
+func (g *GitHub) BodyFormatter() BodyFormatter {
+	return HTMLBodyFormatter{}
+}
+
 // LinkedTopicIssues returns the search URL for linked issues
 func (g *GitHub) LinkedTopicIssues(topicSearchString string) string {
 	values := url.Values{}

--- a/pkg/api/pullRequester.go
+++ b/pkg/api/pullRequester.go
@@ -12,6 +12,8 @@ type PullRequester interface {
 	DefaultBranch(context.Context) string
 	// StackManager returns the stack manager if native stacks are supported, or nil.
 	StackManager() StackManager
+	// BodyFormatter returns the formatter used to render PR body sections.
+	BodyFormatter() BodyFormatter
 }
 
 // PullRequestOptions are the options available to create or update a pull request

--- a/pkg/bitbucket/bitbucket.go
+++ b/pkg/bitbucket/bitbucket.go
@@ -1,0 +1,273 @@
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/api"
+	"github.com/adevinta/maiao/pkg/credentials"
+	"github.com/adevinta/maiao/pkg/log"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+type Bitbucket struct {
+	Host       string
+	Workspace  string
+	RepoSlug   string
+	HTTPClient *http.Client
+	apiBase    string
+}
+
+type pullRequest struct {
+	ID    int `json:"id"`
+	Links struct {
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"links"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	Source struct {
+		Branch struct {
+			Name string `json:"name"`
+		} `json:"branch"`
+	} `json:"source"`
+}
+
+type pullRequestList struct {
+	Values []pullRequest `json:"values"`
+}
+
+type repository struct {
+	MainBranch struct {
+		Name string `json:"name"`
+	} `json:"mainbranch"`
+}
+
+func NewBitbucketUpserter(ctx context.Context, endpoint *transport.Endpoint) (*Bitbucket, error) {
+	orgRepo := strings.Split(strings.Trim(endpoint.Path, "/"), "/")
+	if len(orgRepo) != 2 {
+		return nil, fmt.Errorf("invalid repository path: %s (expected workspace/repo)", endpoint.Path)
+	}
+
+	workspace := orgRepo[0]
+	repoSlug := strings.TrimSuffix(orgRepo[1], ".git")
+
+	credGetter := credentials.CredentialGetterForProvider("bitbucket")
+	cred, err := credGetter.CredentialForHost(endpoint.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credentials for %s: %w", endpoint.Host, err)
+	}
+
+	apiBase := "https://api.bitbucket.org/2.0"
+
+	client := &http.Client{
+		Transport: &basicAuthTransport{
+			username: cred.Username,
+			password: cred.Password,
+			delegate: http.DefaultTransport,
+		},
+	}
+
+	return &Bitbucket{
+		Host:       endpoint.Host,
+		Workspace:  workspace,
+		RepoSlug:   repoSlug,
+		HTTPClient: client,
+		apiBase:    apiBase,
+	}, nil
+}
+
+type basicAuthTransport struct {
+	username string
+	password string
+	delegate http.RoundTripper
+}
+
+func (t *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(t.username, t.password)
+	return t.delegate.RoundTrip(req)
+}
+
+func (b *Bitbucket) Ensure(ctx context.Context, options api.PullRequestOptions) (*api.PullRequest, bool, error) {
+	prs, err := b.listPRs(ctx, options.Head)
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch len(prs) {
+	case 0:
+		pr, err := b.createPR(ctx, options)
+		if err != nil {
+			return nil, false, err
+		}
+		return &api.PullRequest{
+			ID:  fmt.Sprintf("%d", pr.ID),
+			URL: pr.Links.HTML.Href,
+		}, true, nil
+	case 1:
+		return &api.PullRequest{
+			ID:  fmt.Sprintf("%d", prs[0].ID),
+			URL: prs[0].Links.HTML.Href,
+		}, false, nil
+	default:
+		return nil, false, fmt.Errorf("too many matching pull requests (%d)", len(prs))
+	}
+}
+
+func (b *Bitbucket) Update(ctx context.Context, pr *api.PullRequest, options api.PullRequestOptions) (*api.PullRequest, error) {
+	if options.WIP {
+		log.ForContext(ctx).Warn("Bitbucket Cloud does not support draft pull requests")
+	}
+
+	body := map[string]interface{}{
+		"title":       options.Title,
+		"description": options.Body,
+		"destination": map[string]interface{}{
+			"branch": map[string]string{
+				"name": options.Base,
+			},
+		},
+	}
+
+	reqURL := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%s", b.apiBase, b.Workspace, b.RepoSlug, pr.ID)
+	resp, err := b.doJSON(ctx, http.MethodPut, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to update pull request: %s %s", resp.Status, string(respBody))
+	}
+
+	var result pullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return &api.PullRequest{
+		ID:  fmt.Sprintf("%d", result.ID),
+		URL: result.Links.HTML.Href,
+	}, nil
+}
+
+func (b *Bitbucket) DefaultBranch(ctx context.Context) string {
+	reqURL := fmt.Sprintf("%s/repositories/%s/%s", b.apiBase, b.Workspace, b.RepoSlug)
+	resp, err := b.doRequest(ctx, http.MethodGet, reqURL)
+	if err != nil {
+		log.ForContext(ctx).WithError(err).Error("failed to get repository info")
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var r repository
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return ""
+	}
+	return r.MainBranch.Name
+}
+
+func (b *Bitbucket) LinkedTopicIssues(topicSearchString string) string {
+	values := url.Values{}
+	values.Add("search_query", topicSearchString)
+	return fmt.Sprintf("https://%s/%s/%s/pull-requests?%s", b.Host, b.Workspace, b.RepoSlug, values.Encode())
+}
+
+func (b *Bitbucket) StackManager() api.StackManager {
+	return nil
+}
+
+func (b *Bitbucket) listPRs(ctx context.Context, sourceBranch string) ([]pullRequest, error) {
+	query := fmt.Sprintf(`source.branch.name = "%s" AND state = "OPEN"`, sourceBranch)
+	params := url.Values{}
+	params.Add("q", query)
+	reqURL := fmt.Sprintf("%s/repositories/%s/%s/pullrequests?%s", b.apiBase, b.Workspace, b.RepoSlug, params.Encode())
+
+	resp, err := b.doRequest(ctx, http.MethodGet, reqURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to list pull requests: %s %s", resp.Status, string(respBody))
+	}
+
+	var list pullRequestList
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		return nil, err
+	}
+	return list.Values, nil
+}
+
+func (b *Bitbucket) createPR(ctx context.Context, options api.PullRequestOptions) (*pullRequest, error) {
+	if options.WIP {
+		log.ForContext(ctx).Warn("Bitbucket Cloud does not support draft pull requests")
+	}
+
+	body := map[string]interface{}{
+		"title":       options.Title,
+		"description": options.Body,
+		"source": map[string]interface{}{
+			"branch": map[string]string{
+				"name": options.Head,
+			},
+		},
+		"destination": map[string]interface{}{
+			"branch": map[string]string{
+				"name": options.Base,
+			},
+		},
+	}
+
+	reqURL := fmt.Sprintf("%s/repositories/%s/%s/pullrequests", b.apiBase, b.Workspace, b.RepoSlug)
+	resp, err := b.doJSON(ctx, http.MethodPost, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to create pull request: %s %s", resp.Status, string(respBody))
+	}
+
+	var pr pullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+func (b *Bitbucket) doJSON(ctx context.Context, method, reqURL string, body interface{}) (*http.Response, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return b.HTTPClient.Do(req)
+}
+
+func (b *Bitbucket) doRequest(ctx context.Context, method, reqURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return b.HTTPClient.Do(req)
+}

--- a/pkg/bitbucket/bitbucket.go
+++ b/pkg/bitbucket/bitbucket.go
@@ -188,6 +188,10 @@ func (b *Bitbucket) StackManager() api.StackManager {
 	return nil
 }
 
+func (b *Bitbucket) BodyFormatter() api.BodyFormatter {
+	return MarkdownBodyFormatter{}
+}
+
 func (b *Bitbucket) listPRs(ctx context.Context, sourceBranch string) ([]pullRequest, error) {
 	query := fmt.Sprintf(`source.branch.name = "%s" AND state = "OPEN"`, sourceBranch)
 	params := url.Values{}

--- a/pkg/bitbucket/bitbucket_test.go
+++ b/pkg/bitbucket/bitbucket_test.go
@@ -1,0 +1,231 @@
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/adevinta/maiao/pkg/api"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripperFunc func(r *http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+func newTestBitbucket(rt http.RoundTripper) *Bitbucket {
+	return &Bitbucket{
+		Host:       "bitbucket.org",
+		Workspace:  "workspace",
+		RepoSlug:   "repo",
+		HTTPClient: &http.Client{Transport: rt},
+		apiBase:    "https://api.bitbucket.org/2.0",
+	}
+}
+
+func TestEnsureReturnsExistingPR(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		body := `{"values": [{"id": 42, "links": {"html": {"href": "https://bitbucket.org/workspace/repo/pull-requests/42"}}, "state": "OPEN", "source": {"branch": {"name": "maiao.abc123"}}}]}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, created, err := b.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	require.NoError(t, err)
+	assert.False(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "42", pr.ID)
+	assert.Equal(t, "https://bitbucket.org/workspace/repo/pull-requests/42", pr.URL)
+}
+
+func TestEnsureCreatesNewPR(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodGet:
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"values": []}`))}, nil
+		case http.MethodPost:
+			var reqBody map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&reqBody)
+			assert.Equal(t, "Test PR", reqBody["title"])
+			source := reqBody["source"].(map[string]interface{})
+			branch := source["branch"].(map[string]interface{})
+			assert.Equal(t, "maiao.abc123", branch["name"])
+			body := `{"id": 99, "links": {"html": {"href": "https://bitbucket.org/workspace/repo/pull-requests/99"}}}`
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(body))}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	}))
+
+	pr, created, err := b.Ensure(context.Background(), api.PullRequestOptions{
+		Head:  "maiao.abc123",
+		Base:  "main",
+		Title: "Test PR",
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "99", pr.ID)
+	assert.Equal(t, "https://bitbucket.org/workspace/repo/pull-requests/99", pr.URL)
+}
+
+func TestEnsureReturnsErrorWhenTooManyPRs(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := `{"values": [{"id": 1, "links": {"html": {"href": "url1"}}}, {"id": 2, "links": {"html": {"href": "url2"}}}]}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, _, err := b.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	assert.Nil(t, pr)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many matching pull requests")
+}
+
+func TestEnsureReturnsErrorOnAPIFailure(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("error"))}, nil
+	}))
+
+	pr, _, err := b.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	assert.Nil(t, pr)
+	assert.Error(t, err)
+}
+
+func TestUpdatePR(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Contains(t, r.URL.Path, "/pullrequests/42")
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.Equal(t, "Updated Title", reqBody["title"])
+		assert.Equal(t, "Updated Body", reqBody["description"])
+		dest := reqBody["destination"].(map[string]interface{})
+		branch := dest["branch"].(map[string]interface{})
+		assert.Equal(t, "develop", branch["name"])
+		body := `{"id": 42, "links": {"html": {"href": "https://bitbucket.org/workspace/repo/pull-requests/42"}}}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, err := b.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "Updated Title",
+		Body:  "Updated Body",
+		Base:  "develop",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	assert.Equal(t, "42", pr.ID)
+}
+
+func TestUpdateReturnsErrorOnAPIFailure(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader("forbidden"))}, nil
+	}))
+
+	_, err := b.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "Title",
+		Base:  "main",
+	})
+	assert.Error(t, err)
+}
+
+func TestDefaultBranch(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repositories/workspace/repo")
+		body := `{"mainbranch": {"name": "main"}}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	branch := b.DefaultBranch(context.Background())
+	assert.Equal(t, "main", branch)
+}
+
+func TestDefaultBranchReturnsEmptyOnError(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}))
+
+	branch := b.DefaultBranch(context.Background())
+	assert.Equal(t, "", branch)
+}
+
+func TestLinkedTopicIssues(t *testing.T) {
+	b := &Bitbucket{Host: "bitbucket.org", Workspace: "workspace", RepoSlug: "repo"}
+	result := b.LinkedTopicIssues("topic-sha")
+	assert.Contains(t, result, "bitbucket.org/workspace/repo/pull-requests")
+	assert.Contains(t, result, "search_query=topic-sha")
+}
+
+func TestStackManagerReturnsNil(t *testing.T) {
+	b := &Bitbucket{}
+	assert.Nil(t, b.StackManager())
+}
+
+func TestNewBitbucketUpserterInvalidPath(t *testing.T) {
+	b, err := NewBitbucketUpserter(context.Background(), &transport.Endpoint{Host: "bitbucket.org", Path: "invalid"})
+	assert.Error(t, err)
+	assert.Nil(t, b)
+}
+
+func TestNewBitbucketUpserterValidPath(t *testing.T) {
+	old := os.Getenv("BITBUCKET_TOKEN")
+	defer os.Setenv("BITBUCKET_TOKEN", old)
+	os.Setenv("BITBUCKET_TOKEN", "test-token")
+
+	b, err := NewBitbucketUpserter(context.Background(), &transport.Endpoint{Host: "bitbucket.org", Path: "/workspace/repo.git"})
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	assert.Equal(t, "bitbucket.org", b.Host)
+	assert.Equal(t, "workspace", b.Workspace)
+	assert.Equal(t, "repo", b.RepoSlug)
+	assert.Equal(t, "https://api.bitbucket.org/2.0", b.apiBase)
+}
+
+func TestNewBitbucketUpserterNoCredentials(t *testing.T) {
+	old := os.Getenv("BITBUCKET_TOKEN")
+	defer os.Setenv("BITBUCKET_TOKEN", old)
+	os.Unsetenv("BITBUCKET_TOKEN")
+
+	b, err := NewBitbucketUpserter(context.Background(), &transport.Endpoint{Host: "no-cred-host.example.com", Path: "/workspace/repo"})
+	assert.Error(t, err)
+	assert.Nil(t, b)
+}
+
+func TestBasicAuthTransportSetsHeader(t *testing.T) {
+	var capturedAuth string
+	tr := &basicAuthTransport{
+		username: "user",
+		password: "pass",
+		delegate: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			capturedAuth = r.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.bitbucket.org/2.0/repos", nil)
+	tr.RoundTrip(req)
+	assert.NotEmpty(t, capturedAuth)
+	assert.Contains(t, capturedAuth, "Basic")
+}
+
+func TestListPRsUsesQueryFilter(t *testing.T) {
+	b := newTestBitbucket(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Contains(t, r.URL.RawQuery, "source.branch.name")
+		assert.Contains(t, r.URL.RawQuery, "maiao.abc123")
+		body := `{"values": []}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	prs, err := b.listPRs(context.Background(), "maiao.abc123")
+	require.NoError(t, err)
+	assert.Empty(t, prs)
+}

--- a/pkg/bitbucket/formatter.go
+++ b/pkg/bitbucket/formatter.go
@@ -1,6 +1,9 @@
 package bitbucket
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // MarkdownBodyFormatter renders sections as h6 headings with bullet points.
 type MarkdownBodyFormatter struct{}
@@ -11,13 +14,17 @@ func (MarkdownBodyFormatter) Section(title string, content []string) []string {
 		r = append(r, "###### "+title)
 	}
 	for _, line := range content {
-		r = append(r, "- "+line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "- ") {
+			r = append(r, line)
+		} else {
+			r = append(r, "- "+line)
+		}
 	}
 	return r
 }
 
 func (MarkdownBodyFormatter) Link(url, text string) string {
-	return fmt.Sprintf("[%s](%s)", text, url)
+	return fmt.Sprintf("[%s|%s]", text, url)
 }
 
 func (MarkdownBodyFormatter) LineBreak() string {

--- a/pkg/bitbucket/formatter.go
+++ b/pkg/bitbucket/formatter.go
@@ -1,0 +1,25 @@
+package bitbucket
+
+import "fmt"
+
+// MarkdownBodyFormatter renders sections as h6 headings with bullet points.
+type MarkdownBodyFormatter struct{}
+
+func (MarkdownBodyFormatter) Section(title string, content []string) []string {
+	r := []string{}
+	if title != "" {
+		r = append(r, "###### "+title)
+	}
+	for _, line := range content {
+		r = append(r, "- "+line)
+	}
+	return r
+}
+
+func (MarkdownBodyFormatter) Link(url, text string) string {
+	return fmt.Sprintf("[%s](%s)", text, url)
+}
+
+func (MarkdownBodyFormatter) LineBreak() string {
+	return ""
+}

--- a/pkg/bitbucket/formatter.go
+++ b/pkg/bitbucket/formatter.go
@@ -12,6 +12,7 @@ func (MarkdownBodyFormatter) Section(title string, content []string) []string {
 	r := []string{}
 	if title != "" {
 		r = append(r, "###### "+title)
+		r = append(r, "")
 	}
 	for _, line := range content {
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "- ") {
@@ -24,7 +25,7 @@ func (MarkdownBodyFormatter) Section(title string, content []string) []string {
 }
 
 func (MarkdownBodyFormatter) Link(url, text string) string {
-	return fmt.Sprintf("[%s|%s]", text, url)
+	return fmt.Sprintf("[%s](%s)", text, url)
 }
 
 func (MarkdownBodyFormatter) LineBreak() string {

--- a/pkg/bitbucket/formatter_test.go
+++ b/pkg/bitbucket/formatter_test.go
@@ -16,6 +16,28 @@ func TestMarkdownFormatterSectionWithTitle(t *testing.T) {
 	}, result)
 }
 
+func TestMarkdownFormatterSectionPreservesNestedHeadings(t *testing.T) {
+	f := MarkdownBodyFormatter{}
+	inner := f.Section("Parent changes", []string{"first", "second"})
+	result := f.Section("Related changes", inner)
+	assert.Equal(t, []string{
+		"###### Related changes",
+		"###### Parent changes",
+		"- first",
+		"- second",
+	}, result)
+}
+
+func TestMarkdownFormatterSectionPreservesExistingBullets(t *testing.T) {
+	f := MarkdownBodyFormatter{}
+	result := f.Section("Items", []string{"- already a bullet", "plain text"})
+	assert.Equal(t, []string{
+		"###### Items",
+		"- already a bullet",
+		"- plain text",
+	}, result)
+}
+
 func TestMarkdownFormatterSectionWithoutTitle(t *testing.T) {
 	f := MarkdownBodyFormatter{}
 	result := f.Section("", []string{"item one"})
@@ -26,7 +48,7 @@ func TestMarkdownFormatterSectionWithoutTitle(t *testing.T) {
 
 func TestMarkdownFormatterLink(t *testing.T) {
 	f := MarkdownBodyFormatter{}
-	assert.Equal(t, "[my link](https://example.com)", f.Link("https://example.com", "my link"))
+	assert.Equal(t, "[my link|https://example.com]", f.Link("https://example.com", "my link"))
 }
 
 func TestMarkdownFormatterLineBreak(t *testing.T) {

--- a/pkg/bitbucket/formatter_test.go
+++ b/pkg/bitbucket/formatter_test.go
@@ -11,6 +11,7 @@ func TestMarkdownFormatterSectionWithTitle(t *testing.T) {
 	result := f.Section("Related changes", []string{"item one", "item two"})
 	assert.Equal(t, []string{
 		"###### Related changes",
+		"",
 		"- item one",
 		"- item two",
 	}, result)
@@ -22,7 +23,9 @@ func TestMarkdownFormatterSectionPreservesNestedHeadings(t *testing.T) {
 	result := f.Section("Related changes", inner)
 	assert.Equal(t, []string{
 		"###### Related changes",
+		"",
 		"###### Parent changes",
+		"",
 		"- first",
 		"- second",
 	}, result)
@@ -33,6 +36,7 @@ func TestMarkdownFormatterSectionPreservesExistingBullets(t *testing.T) {
 	result := f.Section("Items", []string{"- already a bullet", "plain text"})
 	assert.Equal(t, []string{
 		"###### Items",
+		"",
 		"- already a bullet",
 		"- plain text",
 	}, result)
@@ -48,7 +52,7 @@ func TestMarkdownFormatterSectionWithoutTitle(t *testing.T) {
 
 func TestMarkdownFormatterLink(t *testing.T) {
 	f := MarkdownBodyFormatter{}
-	assert.Equal(t, "[my link|https://example.com]", f.Link("https://example.com", "my link"))
+	assert.Equal(t, "[my link](https://example.com)", f.Link("https://example.com", "my link"))
 }
 
 func TestMarkdownFormatterLineBreak(t *testing.T) {

--- a/pkg/bitbucket/formatter_test.go
+++ b/pkg/bitbucket/formatter_test.go
@@ -1,0 +1,35 @@
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarkdownFormatterSectionWithTitle(t *testing.T) {
+	f := MarkdownBodyFormatter{}
+	result := f.Section("Related changes", []string{"item one", "item two"})
+	assert.Equal(t, []string{
+		"###### Related changes",
+		"- item one",
+		"- item two",
+	}, result)
+}
+
+func TestMarkdownFormatterSectionWithoutTitle(t *testing.T) {
+	f := MarkdownBodyFormatter{}
+	result := f.Section("", []string{"item one"})
+	assert.Equal(t, []string{
+		"- item one",
+	}, result)
+}
+
+func TestMarkdownFormatterLink(t *testing.T) {
+	f := MarkdownBodyFormatter{}
+	assert.Equal(t, "[my link](https://example.com)", f.Link("https://example.com", "my link"))
+}
+
+func TestMarkdownFormatterLineBreak(t *testing.T) {
+	f := MarkdownBodyFormatter{}
+	assert.Equal(t, "", f.LineBreak())
+}

--- a/pkg/credentials/provider.go
+++ b/pkg/credentials/provider.go
@@ -4,22 +4,27 @@ import (
 	"github.com/99designs/keyring"
 )
 
-var envVarForProvider = map[string]string{
-	"github":    "GITHUB_TOKEN",
-	"gitlab":    "GITLAB_TOKEN",
-	"gitea":     "GITEA_TOKEN",
-	"forgejo":   "FORGEJO_TOKEN",
-	"bitbucket": "BITBUCKET_TOKEN",
+type providerEnvConfig struct {
+	passwordKey string
+	usernameKey string
+}
+
+var envVarForProvider = map[string]providerEnvConfig{
+	"github":    {passwordKey: "GITHUB_TOKEN"},
+	"gitlab":    {passwordKey: "GITLAB_TOKEN"},
+	"gitea":     {passwordKey: "GITEA_TOKEN"},
+	"forgejo":   {passwordKey: "FORGEJO_TOKEN"},
+	"bitbucket": {passwordKey: "BITBUCKET_TOKEN", usernameKey: "BITBUCKET_USERNAME"},
 }
 
 func CredentialGetterForProvider(providerType string) CredentialGetter {
-	envKey := envVarForProvider[providerType]
-	if envKey == "" {
-		envKey = "GITHUB_TOKEN"
+	cfg := envVarForProvider[providerType]
+	if cfg.passwordKey == "" {
+		cfg = envVarForProvider["github"]
 	}
 
 	getters := []CredentialGetter{
-		&EnvToken{PasswordKey: envKey},
+		&EnvToken{PasswordKey: cfg.passwordKey, UsernameKey: cfg.usernameKey},
 		&Netrc{},
 		&GitCredentials{GitPath: "git"},
 	}

--- a/pkg/credentials/provider_test.go
+++ b/pkg/credentials/provider_test.go
@@ -55,3 +55,20 @@ func TestCredentialGetterForProviderReturnsErrorWhenNoCredentials(t *testing.T) 
 	_, err := getter.CredentialForHost("non-existent-host-in-netrc.example.com")
 	assert.Error(t, err)
 }
+
+func TestCredentialGetterForBitbucketUsesUsername(t *testing.T) {
+	oldToken := os.Getenv("BITBUCKET_TOKEN")
+	oldUser := os.Getenv("BITBUCKET_USERNAME")
+	defer func() {
+		os.Setenv("BITBUCKET_TOKEN", oldToken)
+		os.Setenv("BITBUCKET_USERNAME", oldUser)
+	}()
+	os.Setenv("BITBUCKET_TOKEN", "app-password")
+	os.Setenv("BITBUCKET_USERNAME", "myuser@example.com")
+
+	getter := CredentialGetterForProvider("bitbucket")
+	cred, err := getter.CredentialForHost("bitbucket.org")
+	require.NoError(t, err)
+	assert.Equal(t, "app-password", cred.Password)
+	assert.Equal(t, "myuser@example.com", cred.Username)
+}

--- a/pkg/gitea/base.go
+++ b/pkg/gitea/base.go
@@ -128,6 +128,10 @@ func (b *BaseClient) StackManager() api.StackManager {
 	return nil
 }
 
+func (b *BaseClient) BodyFormatter() api.BodyFormatter {
+	return api.HTMLBodyFormatter{}
+}
+
 func (b *BaseClient) listPRs(ctx context.Context, head string) ([]pullRequest, error) {
 	params := url.Values{}
 	params.Add("state", "open")

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -179,6 +179,10 @@ func (g *GitLab) StackManager() api.StackManager {
 	return nil
 }
 
+func (g *GitLab) BodyFormatter() api.BodyFormatter {
+	return api.HTMLBodyFormatter{}
+}
+
 func (g *GitLab) listMRs(ctx context.Context, sourceBranch string) ([]mergeRequest, error) {
 	params := url.Values{}
 	params.Add("source_branch", sourceBranch)

--- a/pkg/maiao/factory.go
+++ b/pkg/maiao/factory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/adevinta/maiao/pkg/api"
+	"github.com/adevinta/maiao/pkg/bitbucket"
 	"github.com/adevinta/maiao/pkg/forgejo"
 	"github.com/adevinta/maiao/pkg/gitea"
 	"github.com/adevinta/maiao/pkg/gitlab"
@@ -57,6 +58,13 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := forgejo.NewForgejoUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate forgejo client")
+				continue
+			}
+			return r, nil
+		case provider.Bitbucket:
+			r, err := bitbucket.NewBitbucketUpserter(ctx, endpoint)
+			if err != nil {
+				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate bitbucket client")
 				continue
 			}
 			return r, nil

--- a/pkg/maiao/message.go
+++ b/pkg/maiao/message.go
@@ -9,63 +9,49 @@ import (
 	lgit "github.com/adevinta/maiao/pkg/git"
 )
 
-func details(body []string, summary string) []string {
-	r := []string{"<details>"}
-	if summary != "" {
-		r = append(r,
-			"<summary>",
-			summary,
-			"</summary>",
-		)
-	}
-	r = append(r, body...)
-	r = append(r, "</details>")
-	return r
-}
-
-func topicDetails(prAPI api.PullRequester, topic string) []string {
+func topicDetails(f api.BodyFormatter, prAPI api.PullRequester, topic string) []string {
 	sha := sha1.New()
 	sha.Write([]byte("topic: "))
 	sha.Write([]byte(topic))
 	topicSha := fmt.Sprintf("%x", sha.Sum(nil))
-	return details(
+	return f.Section(
+		"Broader related changes",
 		[]string{
 			"This change is part of a broader topic that can be in multiple repositories.",
-			"<br/>",
-			fmt.Sprintf(`Topic: <a href="%s" searchSha="%v">%s</a>`, prAPI.LinkedTopicIssues(topicSha), topicSha, topic),
+			f.LineBreak(),
+			fmt.Sprintf("Topic: %s", f.Link(prAPI.LinkedTopicIssues(topicSha), topic)),
 		},
-		"Broader related changes",
 	)
 }
 
-func committerDetails(branch string) []string {
-	return details([]string{"Local-Branch: " + branch}, "Committer details")
+func committerDetails(f api.BodyFormatter, branch string) []string {
+	return f.Section("Committer details", []string{"Local-Branch: " + branch})
 }
 
-func changeDetails(changes []*change) []string {
+func changeDetails(f api.BodyFormatter, changes []*change) []string {
 	r := []string{}
 	for _, change := range changes {
 		t := change.message.Title
 		if change.pr != nil {
 			t = fmt.Sprintf("%s (#%s)", t, change.pr.ID)
 		}
-		r = append(r, details([]string{change.message.Body}, t)...)
+		r = append(r, f.Section(t, []string{change.message.Body})...)
 	}
 	return r
 }
 
-func relatedChanges(parents, futures []*change) []string {
+func relatedChanges(f api.BodyFormatter, parents, futures []*change) []string {
 	if len(parents) == 0 && len(futures) == 0 {
 		return []string{}
 	}
 	content := []string{}
 	if len(parents) > 0 {
-		content = append(content, details(changeDetails(parents), "Parent changes")...)
+		content = append(content, f.Section("Parent changes", changeDetails(f, parents))...)
 	}
 	if len(futures) > 0 {
-		content = append(content, details(changeDetails(futures), "Future changes")...)
+		content = append(content, f.Section("Future changes", changeDetails(f, futures))...)
 	}
-	return details(content, "Related changes")
+	return f.Section("Related changes", content)
 }
 
 func prOptions(repo lgit.Repository, prAPI api.PullRequester, options ReviewOptions, change *change, parents, futures []*change) api.PullRequestOptions {
@@ -82,17 +68,19 @@ func prOptions(repo lgit.Repository, prAPI api.PullRequester, options ReviewOpti
 			title = fmt.Sprintf("[need #%s] %s", change.parent.pr.ID, title)
 		}
 	}
+
+	f := prAPI.BodyFormatter()
 	additions := []string{}
 	head, err := repo.Head()
 	if err == nil {
-		additions = committerDetails(head.Name().Short())
+		additions = committerDetails(f, head.Name().Short())
 	}
 	additions = append(
 		additions,
-		relatedChanges(parents, futures)...,
+		relatedChanges(f, parents, futures)...,
 	)
 	if options.Topic != "" {
-		additions = append(additions, topicDetails(prAPI, options.Topic)...)
+		additions = append(additions, topicDetails(f, prAPI, options.Topic)...)
 	}
 
 	return api.PullRequestOptions{

--- a/pkg/maiao/message.go
+++ b/pkg/maiao/message.go
@@ -33,7 +33,7 @@ func changeDetails(f api.BodyFormatter, changes []*change) []string {
 	for _, change := range changes {
 		t := change.message.Title
 		if change.pr != nil {
-			t = fmt.Sprintf("%s (#%s)", t, change.pr.ID)
+			t = fmt.Sprintf("%s (%s)", t, f.Link(change.pr.URL, "#"+change.pr.ID))
 		}
 		r = append(r, f.Section(t, []string{change.message.Body})...)
 	}

--- a/pkg/maiao/message_test.go
+++ b/pkg/maiao/message_test.go
@@ -8,23 +8,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDetailsSkipsMissingSummaries(t *testing.T) {
+func TestHTMLFormatterSectionSkipsMissingSummaries(t *testing.T) {
+	f := api.HTMLBodyFormatter{}
 	assert.Equal(t,
 		[]string{
 			"<details>",
 			"hello world",
 			"</details>",
 		},
-		details(
-			[]string{
-				"hello world",
-			},
-			"",
-		),
+		f.Section("", []string{"hello world"}),
 	)
 }
 
-func TestDetailsIncludesSummary(t *testing.T) {
+func TestHTMLFormatterSectionIncludesSummary(t *testing.T) {
+	f := api.HTMLBodyFormatter{}
 	assert.Equal(t,
 		[]string{
 			"<details>",
@@ -34,16 +31,17 @@ func TestDetailsIncludesSummary(t *testing.T) {
 			"hello world",
 			"</details>",
 		},
-		details(
-			[]string{
-				"hello world",
-			},
-			"summary",
-		),
+		f.Section("summary", []string{"hello world"}),
 	)
 }
 
 func TestTopicDetailsProvidesLink(t *testing.T) {
+	prAPI := &linkedTopicIssuesFunc{
+		linkedTopicIssuesFunc: func(topicSearchString string) string {
+			assert.Equal(t, "89889b28e9672bff47fa4286f4aff4a80e09eade", topicSearchString)
+			return "https://search.example.com/topic"
+		},
+	}
 	assert.Equal(t,
 		[]string{
 			"<details>",
@@ -52,15 +50,10 @@ func TestTopicDetailsProvidesLink(t *testing.T) {
 			"</summary>",
 			"This change is part of a broader topic that can be in multiple repositories.",
 			"<br/>",
-			`Topic: <a href="https://search.example.com/topic" searchSha="89889b28e9672bff47fa4286f4aff4a80e09eade">some topic</a>`,
+			`Topic: <a href="https://search.example.com/topic">some topic</a>`,
 			"</details>",
 		},
-		topicDetails(&linkedTopicIssuesFunc{
-			linkedTopicIssuesFunc: func(topicSearchString string) string {
-				assert.Equal(t, "89889b28e9672bff47fa4286f4aff4a80e09eade", topicSearchString)
-				return "https://search.example.com/topic"
-			},
-		}, "some topic"),
+		topicDetails(api.HTMLBodyFormatter{}, prAPI, "some topic"),
 	)
 }
 
@@ -71,6 +64,10 @@ type linkedTopicIssuesFunc struct {
 
 func (l linkedTopicIssuesFunc) LinkedTopicIssues(topicSearchString string) string {
 	return l.linkedTopicIssuesFunc(topicSearchString)
+}
+
+func (l linkedTopicIssuesFunc) BodyFormatter() api.BodyFormatter {
+	return api.HTMLBodyFormatter{}
 }
 
 func TestPrOptionsTitleStripsWIPBeforeNeedPrefix(t *testing.T) {

--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -414,6 +414,9 @@ func defaultBranchOption(ctx context.Context, repo lgit.Repository, prAPI api.Pu
 			options.Branch = prAPI.DefaultBranch(ctx)
 		}
 		if options.Branch == "" {
+			options.Branch = remoteDefaultBranch(repo, options.Remote)
+		}
+		if options.Branch == "" {
 			options.Branch = "master"
 		}
 		if err != nil {
@@ -428,6 +431,23 @@ func defaultBranchOption(ctx context.Context, repo lgit.Repository, prAPI api.Pu
 			}
 		}
 	}
+}
+
+func remoteDefaultBranch(repo lgit.Repository, remoteName string) string {
+	if remoteName == "" {
+		remoteName = defaultRemote
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", wt.Filesystem.Root(), "symbolic-ref", fmt.Sprintf("refs/remotes/%s/HEAD", remoteName)).Output()
+	if err != nil {
+		return ""
+	}
+	ref := strings.TrimSpace(string(out))
+	prefix := fmt.Sprintf("refs/remotes/%s/", remoteName)
+	return strings.TrimPrefix(ref, prefix)
 }
 
 func defaultRemoteOption(ctx context.Context, repo lgit.Repository, options *ReviewOptions) {

--- a/pkg/maiao/review_test.go
+++ b/pkg/maiao/review_test.go
@@ -149,6 +149,10 @@ func (a *testAPI) StackManager() api.StackManager {
 	return nil
 }
 
+func (a *testAPI) BodyFormatter() api.BodyFormatter {
+	return api.HTMLBodyFormatter{}
+}
+
 func TestDefaultOptionsUsesGitDefaults(t *testing.T) {
 	opts := ReviewOptions{}
 	repo := &testRepository{}


### PR DESCRIPTION
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
feat: add provider detection infrastructure for multi-provider support (<a href="https://github.com/runetes/maiao/pull/12">#12</a>)
</summary>
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
</details>
<details>
<summary>
feat: add provider-aware credential resolution (<a href="https://github.com/runetes/maiao/pull/13">#13</a>)
</summary>
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
</details>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
<details>
<summary>
feat: add Gitea pull request support (<a href="https://github.com/runetes/maiao/pull/15">#15</a>)
</summary>
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
</details>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
fix: auto-resolve SSH known_hosts errors with interactive prompt (<a href="https://github.com/runetes/maiao/pull/18">#18</a>)
</summary>
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
</details>
<details>
<summary>
docs: update documentation for multi-provider support (<a href="https://github.com/runetes/maiao/pull/19">#19</a>)
</summary>
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
</details>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
<details>
<summary>
fix: surface actual error when provider client creation fails (<a href="https://github.com/runetes/maiao/pull/21">#21</a>)
</summary>
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
</details>
<details>
<summary>
feat: add Cursor Origin provider support (beta) (<a href="https://github.com/runetes/maiao/pull/23">#23</a>)
</summary>
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
</details>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>