### PR TITLE
[need #17] fix: auto-resolve SSH known_hosts errors with interactive prompt

### DIFF
--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -14,6 +14,7 @@ import (
 	lgit "github.com/adevinta/maiao/pkg/git"
 	"github.com/adevinta/maiao/pkg/log"
 	"github.com/adevinta/maiao/pkg/provider"
+	mssh "github.com/adevinta/maiao/pkg/ssh"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -99,13 +100,19 @@ func Review(ctx context.Context, repo lgit.Repository, options ReviewOptions) er
 	credGetter := credentials.CredentialGetterForProvider(string(providerType))
 
 	log.ForContext(ctx).Debugf("fetching remote")
-	err = remote.Fetch(&git.FetchOptions{
+	fetchOpts := &git.FetchOptions{
 		RemoteName: options.Remote,
 		Auth:       &credentials.GitAuth{Credentials: credGetter, Endpoint: endpoint},
-	})
+	}
+	err = remote.Fetch(fetchOpts)
 	if err != nil && err != git.NoErrAlreadyUpToDate {
-		log.ForContext(ctx).WithError(err).Error("failed to update git repository")
-		return err
+		if fixErr := handleSSHHostKeyError(err, endpoint.Host); fixErr == nil {
+			err = remote.Fetch(fetchOpts)
+		}
+		if err != nil && err != git.NoErrAlreadyUpToDate {
+			log.ForContext(ctx).WithError(err).Error("failed to update git repository")
+			return err
+		}
 	}
 	headRef := plumbing.Revision(plumbing.HEAD)
 	ctx = log.WithContextFields(ctx, logrus.Fields{
@@ -262,12 +269,18 @@ func sendPrs(ctx context.Context, repo lgit.Repository, options ReviewOptions, b
 	credGetter := credentials.CredentialGetterForProvider(string(providerType))
 
 	log.ForContext(ctx).WithField("refspec", refspecs).Debugf("pushing PR changes")
-	err = repo.Push(&git.PushOptions{
+	pushOpts := &git.PushOptions{
 		RemoteName: options.Remote,
 		RefSpecs:   refspecs,
 		Auth:       &credentials.GitAuth{Credentials: credGetter, Endpoint: endpoint},
 		Force:      true,
-	})
+	}
+	err = repo.Push(pushOpts)
+	if err != nil && err != git.NoErrAlreadyUpToDate {
+		if fixErr := handleSSHHostKeyError(err, endpoint.Host); fixErr == nil {
+			err = repo.Push(pushOpts)
+		}
+	}
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		return err
 	}
@@ -570,4 +583,15 @@ func extractChanges(ctx context.Context, repo lgit.Repository, base, head plumbi
 			}
 		}
 	}
+}
+
+func handleSSHHostKeyError(err error, endpointHost string) error {
+	host, isMismatch, ok := mssh.IsKnownHostsError(err)
+	if !ok {
+		return err
+	}
+	if host == "" {
+		host = endpointHost
+	}
+	return mssh.PromptAndFix(host, isMismatch)
 }

--- a/pkg/ssh/knownhosts.go
+++ b/pkg/ssh/knownhosts.go
@@ -1,0 +1,106 @@
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/prompt"
+)
+
+func IsKnownHostsError(err error) (host string, isMismatch bool, ok bool) {
+	if err == nil {
+		return "", false, false
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "knownhosts: key mismatch") {
+		return extractHostFromError(msg), true, true
+	}
+	if strings.Contains(msg, "knownhosts: key is unknown") {
+		return extractHostFromError(msg), false, true
+	}
+	return "", false, false
+}
+
+func PromptAndFix(host string, isMismatch bool) error {
+	var question string
+	if isMismatch {
+		question = fmt.Sprintf("SSH host key mismatch for %s (the server's key has changed). Update it?", host)
+	} else {
+		question = fmt.Sprintf("SSH host key not found for %s. Add it automatically?", host)
+	}
+
+	if !prompt.YesNo(question) {
+		return fmt.Errorf("SSH host key issue for %s not resolved", host)
+	}
+
+	if isMismatch {
+		if err := removeHostKeys(host); err != nil {
+			return fmt.Errorf("failed to remove old host keys: %w", err)
+		}
+	}
+
+	if err := addHostKeys(host); err != nil {
+		return fmt.Errorf("failed to add host keys: %w", err)
+	}
+
+	return nil
+}
+
+func removeHostKeys(host string) error {
+	cmd := exec.Command("ssh-keygen", "-R", host)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func addHostKeys(host string) error {
+	knownHostsPath := filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
+
+	if err := os.MkdirAll(filepath.Dir(knownHostsPath), 0700); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("ssh-keyscan", host)
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("ssh-keyscan failed: %w", err)
+	}
+	if len(out) == 0 {
+		return fmt.Errorf("ssh-keyscan returned no keys for %s", host)
+	}
+
+	f, err := os.OpenFile(knownHostsPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(out)
+	return err
+}
+
+func extractHostFromError(msg string) string {
+	// go-git wraps errors like:
+	// "ssh: handshake failed: knownhosts: key mismatch"
+	// The host isn't always in the error message itself, but we can check
+	// for common patterns. We'll rely on the caller passing the host from
+	// the endpoint when the error message doesn't contain it.
+	//
+	// Some versions include the host in brackets: [host]:port
+	// Try to extract from common patterns
+	for _, prefix := range []string{"dial tcp ", "connect to "} {
+		if idx := strings.Index(msg, prefix); idx >= 0 {
+			rest := msg[idx+len(prefix):]
+			if colonIdx := strings.Index(rest, ":"); colonIdx > 0 {
+				host := rest[:colonIdx]
+				host = strings.TrimPrefix(host, "[")
+				host = strings.TrimSuffix(host, "]")
+				return host
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/ssh/knownhosts_test.go
+++ b/pkg/ssh/knownhosts_test.go
@@ -1,0 +1,63 @@
+package ssh
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsKnownHostsErrorNilError(t *testing.T) {
+	_, _, ok := IsKnownHostsError(nil)
+	assert.False(t, ok)
+}
+
+func TestIsKnownHostsErrorUnrelatedError(t *testing.T) {
+	_, _, ok := IsKnownHostsError(errors.New("connection refused"))
+	assert.False(t, ok)
+}
+
+func TestIsKnownHostsErrorKeyMismatch(t *testing.T) {
+	err := errors.New("ssh: handshake failed: knownhosts: key mismatch")
+	_, isMismatch, ok := IsKnownHostsError(err)
+	assert.True(t, ok)
+	assert.True(t, isMismatch)
+}
+
+func TestIsKnownHostsErrorKeyUnknown(t *testing.T) {
+	err := errors.New("ssh: handshake failed: knownhosts: key is unknown")
+	_, isMismatch, ok := IsKnownHostsError(err)
+	assert.True(t, ok)
+	assert.False(t, isMismatch)
+}
+
+func TestIsKnownHostsErrorExtractsHostFromDialTcp(t *testing.T) {
+	err := errors.New("dial tcp gitlab.com:22: knownhosts: key mismatch")
+	host, isMismatch, ok := IsKnownHostsError(err)
+	assert.True(t, ok)
+	assert.True(t, isMismatch)
+	assert.Equal(t, "gitlab.com", host)
+}
+
+func TestIsKnownHostsErrorExtractsHostFromBrackets(t *testing.T) {
+	err := errors.New("dial tcp [gitlab.com]:22: knownhosts: key mismatch")
+	host, _, ok := IsKnownHostsError(err)
+	assert.True(t, ok)
+	assert.Equal(t, "gitlab.com", host)
+}
+
+func TestIsKnownHostsErrorReturnsEmptyHostWhenNotParseable(t *testing.T) {
+	err := errors.New("knownhosts: key mismatch")
+	host, _, ok := IsKnownHostsError(err)
+	assert.True(t, ok)
+	assert.Equal(t, "", host)
+}
+
+func TestAddHostKeysIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	// Verify ssh-keyscan is available
+	err := addHostKeys("github.com")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
feat: add provider detection infrastructure for multi-provider support (<a href="https://github.com/runetes/maiao/pull/12">#12</a>)
</summary>
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
</details>
<details>
<summary>
feat: add provider-aware credential resolution (<a href="https://github.com/runetes/maiao/pull/13">#13</a>)
</summary>
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
</details>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
<details>
<summary>
feat: add Gitea pull request support (<a href="https://github.com/runetes/maiao/pull/15">#15</a>)
</summary>
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
</details>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
<details>
<summary>
feat: add Bitbucket Cloud pull request support (<a href="https://github.com/runetes/maiao/pull/17">#17</a>)
</summary>
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
docs: update documentation for multi-provider support (<a href="https://github.com/runetes/maiao/pull/19">#19</a>)
</summary>
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
</details>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
<details>
<summary>
fix: surface actual error when provider client creation fails (<a href="https://github.com/runetes/maiao/pull/21">#21</a>)
</summary>
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
</details>
<details>
<summary>
feat: add Cursor Origin provider support (beta) (<a href="https://github.com/runetes/maiao/pull/23">#23</a>)
</summary>
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
</details>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>