### PR TITLE
[need #18] docs: update documentation for multi-provider support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,20 +6,33 @@
 
 > **Note:** This is a community fork of [adevinta/maiao](https://github.com/adevinta/maiao). The original maintainers are no longer at Adevinta and the upstream repository is no longer actively maintained. This fork continues development under [runetes/maiao](https://github.com/runetes/maiao).
 
-**Gerrit-style code review workflow for GitHub**
+**Gerrit-style code review workflow for GitHub, GitLab, Gitea, Forgejo, and Bitbucket Cloud**
 
-Maiao brings the power of **stacked pull requests** to GitHub, enabling you to break large features into small, reviewable commits where each commit becomes its own PR.
+Maiao brings the power of **stacked pull requests** (or merge requests) to your git hosting provider, enabling you to break large features into small, reviewable commits where each commit becomes its own PR/MR.
 
 ## What is Maiao?
 
 Maiao provides the `git review` command that:
 
-- **Creates one PR per commit** in your branch
-- **Stacks PRs automatically** with proper parent-child dependencies
-- **Registers native GitHub Stacks** when available, for first-class UI support
+- **Creates one PR/MR per commit** in your branch
+- **Stacks PRs/MRs automatically** with proper parent-child dependencies
+- **Registers native stacks** when available (GitHub Stacks, GitLab auto-detected stacks)
 - **Manages fixups elegantly** using `git commit --fixup`
 - **Tracks commits via Change-IDs** (using the Gerrit commit-msg hook)
-- **Auto-rebases your stack** when PRs get merged
+- **Auto-rebases your stack** when PRs/MRs get merged
+- **Auto-detects your provider** from the remote URL
+
+## Supported Providers
+
+| Provider | PR/MR type | WIP/Draft | Native stacks |
+|----------|------------|-----------|---------------|
+| GitHub | Pull Request | API field | Yes (explicit registration) |
+| GitLab | Merge Request | `Draft:` title prefix | Yes (auto-detected from target branch, up to 20 MRs) |
+| Gitea | Pull Request | `WIP:` title prefix | No |
+| Forgejo/Codeberg | Pull Request | `WIP:` title prefix | No |
+| Bitbucket Cloud | Pull Request | Not supported | No |
+
+Maiao auto-detects the provider from your remote URL for known hosts (`github.com`, `gitlab.com`, `codeberg.org`, `bitbucket.org`). For self-hosted instances, it prompts on first use and saves the choice to `git config maiao.provider`.
 
 ## Quick Example
 
@@ -29,11 +42,11 @@ git commit -m "Add user authentication"
 git commit -m "Add authorization middleware"
 git commit -m "Add admin endpoints"
 
-# Create stacked PRs for all commits
+# Create stacked PRs/MRs for all commits
 git review
 ```
 
-**Result**: Three GitHub PRs created and registered as a native stack:
+**Result**: Three PRs/MRs created and stacked:
 
 - PR #1: `Add user authentication` → `main`
 - PR #2: `Add authorization middleware` → PR #1
@@ -42,12 +55,13 @@ git review
 ## Key Benefits
 
 - **Granular Reviews**: Each commit reviewed independently for faster, focused feedback
-- **Clear History**: One logical change per PR maintains clean git history
+- **Clear History**: One logical change per PR/MR maintains clean git history
 - **Easy Fixups**: Address review feedback with `git commit --fixup <sha>`
-- **Automatic Stacking**: Tool manages PR dependencies automatically
-- **Native GitHub Stacks**: Integrates with GitHub's stack UI for unified review and merge controls
-- **Merge Detection**: Stack updates automatically when PRs merge
+- **Automatic Stacking**: Tool manages PR/MR dependencies automatically
+- **Native Stacks**: Integrates with GitHub Stacks and GitLab's auto-detected stacks
+- **Merge Detection**: Stack updates automatically when PRs/MRs merge
 - **Rebase Integration**: Handles upstream changes gracefully
+- **Multi-Provider**: Works across GitHub, GitLab, Gitea, Forgejo, and Bitbucket Cloud
 
 ## Native GitHub Stacks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,13 +1,13 @@
 # Getting Started
 
-Welcome to Maiao! This guide will help you set up and start using stacked pull requests in your GitHub workflow.
+Welcome to Maiao! This guide will help you set up and start using stacked pull requests (or merge requests) in your workflow.
 
 ## 📋 Prerequisites
 
 Before installing Maiao, ensure you have:
 - Git installed (version 2.0+)
-- GitHub account with repository access
-- GitHub Personal Access Token with `repo` scope ([create one here](https://github.com/settings/tokens))
+- An account on your git hosting provider (GitHub, GitLab, Gitea, Forgejo, or Bitbucket Cloud)
+- An API token for your provider (see [Configuration](#-configuration) below)
 
 ## 📦 Installation
 
@@ -57,26 +57,101 @@ go build -o /usr/local/bin/git-review ./cmd/maiao
 
 ## ⚙️ Configuration
 
-### GitHub Authentication
+### Provider Detection
 
-Create a `~/.netrc` file with your GitHub credentials:
+Maiao auto-detects your provider from the remote URL for known hosts:
+- `github.com` → GitHub
+- `gitlab.com` → GitLab
+- `codeberg.org` → Forgejo
+- `bitbucket.org` → Bitbucket Cloud
 
+For self-hosted instances, Maiao prompts you on first use and saves the choice:
+
+```bash
+git config maiao.provider gitlab  # or: github, gitea, forgejo, bitbucket
+```
+
+### Authentication
+
+Maiao tries credentials in this order: environment variable → `~/.netrc` → git credential helpers → system keychain.
+
+#### GitHub / GitHub Enterprise
+
+```bash
+export GITHUB_TOKEN=<your-personal-access-token>
+```
+
+Or via `~/.netrc`:
 ```
 machine github.com
   login your.username@example.com
   password <your-personal-access-token>
 ```
 
-**For GitHub Enterprise:**
+Create a token with `repo` scope at [github.com/settings/tokens](https://github.com/settings/tokens).
+
+#### GitLab
+
+```bash
+export GITLAB_TOKEN=<your-personal-access-token>
 ```
-machine github.company.example.com
-  login firstname.lastname@company.example.com
-  password <your-token>
+
+Or via `~/.netrc`:
 ```
+machine gitlab.com
+  login your.username@example.com
+  password <your-personal-access-token>
+```
+
+Create a token with `api` scope at Settings → Access Tokens.
+
+#### Gitea
+
+```bash
+export GITEA_TOKEN=<your-access-token>
+```
+
+Or via `~/.netrc`:
+```
+machine your-gitea-instance.com
+  login your-username
+  password <your-access-token>
+```
+
+#### Forgejo / Codeberg
+
+```bash
+export FORGEJO_TOKEN=<your-access-token>
+```
+
+Or via `~/.netrc`:
+```
+machine codeberg.org
+  login your-username
+  password <your-access-token>
+```
+
+#### Bitbucket Cloud
+
+Bitbucket Cloud requires basic auth with your Atlassian email and an app password:
+
+```bash
+export BITBUCKET_USERNAME=your-email@example.com
+export BITBUCKET_TOKEN=<your-app-password>
+```
+
+Or via `~/.netrc`:
+```
+machine bitbucket.org
+  login your-email@example.com
+  password <your-app-password>
+```
+
+Create an app password at [Bitbucket Settings → App passwords](https://bitbucket.org/account/settings/app-passwords/) with `Repositories: Read/Write` and `Pull requests: Read/Write` permissions.
 
 ### 🔐 Experimental: System Keychain (Optional)
 
-Use your OS keychain (macOS Keychain, pass, etc.) instead of `.netrc`:
+Use your OS keychain (macOS Keychain, pass, etc.) instead of environment variables or `.netrc`:
 
 ```bash
 export MAIAO_EXPERIMENTAL_CREDENTIALS=true
@@ -113,13 +188,15 @@ Maiao aims to solve the classic code review problem:
 
 ![](img/code_reviews_tweet.jpeg)
 
-**Philosophy**: Create small, self-contained commits. Each commit becomes a reviewable PR, stacked on the previous one.
+**Philosophy**: Create small, self-contained commits. Each commit becomes a reviewable PR/MR, stacked on the previous one.
 
 **Benefits**:
 - ✅ Faster reviews (smaller changesets)
 - ✅ Better feedback (focused on one change)
 - ✅ Cleaner history (atomic commits)
 - ✅ Easier debugging (bisectable changes)
+
+This workflow works identically across all supported providers — GitHub PRs, GitLab MRs, etc.
 
 ## 🎯 Basic Workflow Example
 
@@ -255,70 +332,6 @@ git review
 
 Maiao groups all fixups by their target commit and updates PRs accordingly.
 
-## Installation
-
-### Homebrew users
-
-To install maiao with homebrew, you need to tap the repo before installing it:
-
-```bash
-brew tap runetes/maiao https://github.com/runetes/maiao.git
-brew install maiao
-```
-
-### Unix users
-
-The simplest way to install maiao is to download the binary from github. To do so, visit
-the [releases](https://github.com/runetes/maiao/releases) page and download the version you want to install. Then run
-
-```
-mv <downloadsDir>/git-review-`uname -s`-`uname -m` /usr/local/bin/git-review
-chmod +x /usr/local/bin/git-review
-```
-
-!!! warning "MacOS users"
-To make sure the binary is not quarantined run: `xattr -d com.apple.quarantine /usr/local/bin/git-review`
-
-To build a standalone binary, you will need to run `go build -o /usr/local/bin/git-review ./cmd/maiao`
-
-### Windows users
-
-The relevant Windows binary can be downloaded in the [releases](https://github.com/runetes/maiao/releases) page
-
-Download the `git-review-windows-<arch>` where `<arch>` is the architecture of your machine. If you are unsure, usually,
-amd64 is the default windows architecture.
-
-## Configuration
-
-If you have ever installed and configured `adv` command line, you should already be good to go. If not, you will need to
-configure a github token in your netrc file. To do so, follow these steps:
-
-Create your personal [access token](https://github.company.example.com/settings/tokens) with `repo` privileges and
-create a file `~/.netrc` having the following content:
-
-```
-machine github.company.example.com
-  login <firstname>.<lastname>@company.example.com
-  password <your token>
-```
-
-### Experimental system keychain
-
-You may now use all the default keyrings supported by [`99-designs/keyring`](https://pkg.go.dev/github.com/99designs/keyring@v1.2.2#section-readme).
-
-To enable it, ensure you export the `MAIAO_EXPERIMENTAL_CREDENTIALS=true` environment variable before running `git review`.
-Maiao will then use your system keyring like [macOS keychain](https://support.apple.com/en-au/guide/keychain-access/welcome/mac) or [pass](https://www.passwordstore.org/)
-to store GitHub API keys.
-
-We will be happy to receive your feedback about this feature in [maiao's issues](https://github.com/runetes/maiao/issues) 
-
-
-Your environment is then ready to run maiao.
-
-There will be some other configuration required for each repository you need to run maiao on. Don't worry, maiao will
-prompt and suggest you to perform the setup if the configuration is missing.
-
-
 ## 🎓 Understanding Key Concepts
 
 ### Change-IDs
@@ -336,7 +349,7 @@ Change-Id: I8f3c2a1b5e9d7f6a4c3b2a1d0e9f8c7b6a5d4e3f
 **Purpose:**
 - Tracks commits across rebases
 - Enables fixup commit matching
-- Maps commits to GitHub branches
+- Maps commits to remote branches
 
 **Generated by:** Gerrit commit-msg hook (installed via `git review install`)
 
@@ -439,9 +452,38 @@ git rebase origin/main
 
 **Solution:**
 ```bash
-# Check ~/.netrc has correct token
-# Or verify GitHub token has 'repo' scope
-# Recreate token: https://github.com/settings/tokens
+# Check your token is set (see Configuration section above)
+# Verify token has the right scopes for your provider
+# For Bitbucket: ensure both BITBUCKET_USERNAME and BITBUCKET_TOKEN are set
+```
+
+### "401 Unauthorized" on Bitbucket
+
+**Problem:** Bitbucket Cloud requires basic auth with your Atlassian email
+
+**Solution:**
+```bash
+export BITBUCKET_USERNAME=your-email@example.com
+export BITBUCKET_TOKEN=your-app-password
+```
+
+### SSH host key error
+
+**Problem:** SSH host key not found or has changed (common when connecting to a new provider for the first time)
+
+**Solution:** Maiao will automatically prompt you to resolve this via `ssh-keyscan`. Accept the prompt to add the host key.
+
+### "reference not found"
+
+**Problem:** Default branch detection failed (e.g., repo uses "main" but Maiao falls back to "master")
+
+**Solution:**
+```bash
+# Pass the target branch explicitly
+git review main
+
+# Or ensure remote HEAD is set
+git remote set-head origin --auto
 ```
 
 ### "unmatched fixups"

--- a/docs/how-does-it-work.md
+++ b/docs/how-does-it-work.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Overview
 
-Maiao implements a **stacked diffs** workflow for GitHub, inspired by Gerrit's code review model. It transforms your linear commit history into individual, stacked pull requests where each commit is independently reviewable while maintaining proper dependencies.
+Maiao implements a **stacked diffs** workflow for GitHub, GitLab, Gitea, Forgejo, and Bitbucket Cloud, inspired by Gerrit's code review model. It transforms your linear commit history into individual, stacked pull requests (or merge requests) where each commit is independently reviewable while maintaining proper dependencies.
 
 ## 📚 Background: Stacked Diffs
 
@@ -31,7 +31,7 @@ Change-Id: I8f3c2a1b5e9d7f6a4c3b2a1d0e9f8c7b6a5d4e3f
 
 1. **Track commits across rebases**: Change-ID remains constant even when commit SHA changes
 2. **Enable fixup matching**: `git commit --fixup` matches commits by title, Change-ID confirms the match
-3. **Map to GitHub branches**: Each Change-ID generates a unique branch name (`maiao.<Change-ID>`)
+3. **Map to remote branches**: Each Change-ID generates a unique branch name (`maiao.<Change-ID>`)
 4. **Detect merged changes**: Identify which commits already exist in the target branch
 
 ### How Change-IDs are Generated
@@ -51,7 +51,7 @@ Each commit creates an **ephemeral remote branch**: `maiao.<Change-ID>`
 ```
 Commit SHA:    abc1234567890def
 Change-ID:     I8f3c2a1b5e9d7f6a4c3b2a1d0e9f8c7b6a5d4e3f
-GitHub Branch: maiao.I8f3c2a1b5e9d7f6a4c3b2a1d0e9f8c7b6a5d4e3f
+Remote Branch: maiao.I8f3c2a1b5e9d7f6a4c3b2a1d0e9f8c7b6a5d4e3f
 ```
 
 **Key Properties:**
@@ -183,7 +183,7 @@ repo.Push(&git.PushOptions{
 })
 ```
 
-**Result on GitHub:**
+**Result on remote:**
 ```
 origin/main  → I (commit I's SHA)
 maiao.I111   → A' (commit A's rebased SHA)
@@ -200,18 +200,20 @@ var parent *change
 for i, change := range changes {
     change.parent = parent
 
-    // Build PR options with stacking
+    // Build PR/MR options with stacking
     opts := prOptions(repo, prAPI, options, change, changes[:i], changes[i+1:])
 
-    // Create or find existing PR
+    // Create or find existing PR/MR via the PullRequester interface
     pr, created, err := prAPI.Ensure(ctx, opts)
 
     change.pr = pr
-    parent = change  // Next PR stacks on this one
+    parent = change  // Next PR/MR stacks on this one
 }
 ```
 
-**PR Structure Created:**
+The `PullRequester` interface abstracts the provider-specific API. Each provider (GitHub, GitLab, Gitea, Forgejo, Bitbucket) implements `Ensure()` and `Update()` using its own REST API.
+
+**PR/MR Structure Created:**
 ```
 PR #1: maiao.I111 → origin/main
        Title: "Add user authentication"
@@ -228,6 +230,8 @@ PR #3: maiao.I333 → maiao.I222
        Base: maiao.I222  ← Stacked on PR #2
        Head: maiao.I333
 ```
+
+On GitLab, this target-branch chaining is automatically detected as a stack (up to 20 MRs).
 
 ## 📊 Visual Workflow Example
 
@@ -379,6 +383,39 @@ PR #2 base changed: maiao.I111 → origin/main
 PR #3 base unchanged: maiao.I222 (rebased)
 ```
 
+## 🌐 Provider Architecture
+
+### Auto-Detection
+
+Maiao detects the provider from your remote URL (`pkg/provider/detect.go`):
+
+1. **Known hosts** — `github.com`, `gitlab.com`, `codeberg.org`, `bitbucket.org` are mapped automatically
+2. **Git config** — reads `git config maiao.provider` for self-hosted instances
+3. **Interactive prompt** — if unknown, prompts the user to select a provider and saves to git config
+
+### Credential Chain
+
+For each provider, Maiao tries credentials in order (`pkg/credentials/provider.go`):
+
+1. **Environment variable** — `GITHUB_TOKEN`, `GITLAB_TOKEN`, `GITEA_TOKEN`, `FORGEJO_TOKEN`, or `BITBUCKET_TOKEN` (+ `BITBUCKET_USERNAME`)
+2. **Netrc** — `~/.netrc` machine entries
+3. **Git credential helpers** — whatever `git credential fill` returns
+4. **System keychain** — macOS Keychain, pass, etc. (experimental)
+
+### WIP/Draft Handling
+
+Each provider handles work-in-progress differently:
+- **GitHub** — sets `draft: true` via the API
+- **GitLab** — prefixes title with `Draft: `
+- **Gitea/Forgejo** — prefixes title with `WIP: `
+- **Bitbucket** — no draft support (logs a warning)
+
+Maiao strips `WIP:`/`Draft:` from commit titles, detects the intent, and lets each provider apply it in its own way.
+
+### SSH Host Key Resolution
+
+When connecting to a provider via SSH for the first time, go-git's `knownhosts` library may fail if the host key isn't in `~/.ssh/known_hosts`. Maiao automatically detects this, prompts the user, and runs `ssh-keyscan` to add all key types.
+
 ## 🔍 Technical Deep Dive
 
 ### Commit Message Parsing
@@ -419,32 +456,29 @@ func (m *Message) GetChangeID() (changeID string, ok bool) {
 }
 ```
 
-### GitHub API Integration
+### Provider API Integration
 
-**Code:** `pkg/api/github.go:48-96`
+**Interface:** `pkg/api/pullRequester.go`
 
 ```go
-func (g *GitHub) Ensure(ctx, options) (*PullRequest, bool, error) {
-    // 1. List existing PRs for this head branch
-    prs := g.PullRequests.List(ctx, g.Owner, g.Repository, &github.PullRequestListOptions{
-        Head: g.Owner + ":" + options.Head,
-    })
-
-    switch len(prs) {
-    case 0:
-        // Create new PR
-        pr := g.PullRequests.Create(ctx, g.Owner, g.Repository, &github.NewPullRequest{
-            Title: options.Title,
-            Body:  options.Body,
-            Base:  options.Base,
-            Head:  options.Head,
-        })
-        return pr, true, nil  // Created
-    case 1:
-        return prs[0], false, nil  // Already exists
-    }
+type PullRequester interface {
+    Ensure(context.Context, PullRequestOptions) (*PullRequest, bool, error)
+    Update(context.Context, *PullRequest, PullRequestOptions) (*PullRequest, error)
+    LinkedTopicIssues(topicSearchString string) string
+    DefaultBranch(context.Context) string
+    StackManager() StackManager
+    BodyFormatter() BodyFormatter
 }
 ```
+
+Each provider implements this interface:
+- **GitHub** (`pkg/api/github.go`) — uses the `google/go-github` SDK
+- **GitLab** (`pkg/gitlab/`) — REST v4 API with `PRIVATE-TOKEN` header
+- **Gitea** (`pkg/gitea/`) — REST v1 API with `Authorization: token` header
+- **Forgejo** (`pkg/forgejo/`) — embeds Gitea's base client
+- **Bitbucket Cloud** (`pkg/bitbucket/`) — REST 2.0 API with basic auth
+
+The `BodyFormatter` interface controls how PR body sections are rendered: HTML `<details>` for GitHub/GitLab/Gitea/Forgejo, Markdown headings for Bitbucket.
 
 ### Force Push Strategy
 
@@ -536,7 +570,7 @@ Change-IDs persist across:
 
 **Protected against:**
 - Multiple `git review` runs (last write wins, deterministic)
-- Simultaneous PR creation (GitHub API handles duplicates)
+- Simultaneous PR creation (provider APIs handle duplicates)
 
 **Not protected against:**
 - Manual edits to `maiao.*` branches (will be overwritten)


### PR DESCRIPTION
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
feat: add provider detection infrastructure for multi-provider support (<a href="https://github.com/runetes/maiao/pull/12">#12</a>)
</summary>
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
</details>
<details>
<summary>
feat: add provider-aware credential resolution (<a href="https://github.com/runetes/maiao/pull/13">#13</a>)
</summary>
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
</details>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
<details>
<summary>
feat: add Gitea pull request support (<a href="https://github.com/runetes/maiao/pull/15">#15</a>)
</summary>
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
</details>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
<details>
<summary>
feat: add Bitbucket Cloud pull request support (<a href="https://github.com/runetes/maiao/pull/17">#17</a>)
</summary>
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
</details>
<details>
<summary>
fix: auto-resolve SSH known_hosts errors with interactive prompt (<a href="https://github.com/runetes/maiao/pull/18">#18</a>)
</summary>
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
<details>
<summary>
fix: surface actual error when provider client creation fails (<a href="https://github.com/runetes/maiao/pull/21">#21</a>)
</summary>
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
</details>
<details>
<summary>
feat: add Cursor Origin provider support (beta) (<a href="https://github.com/runetes/maiao/pull/23">#23</a>)
</summary>
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
</details>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>