### PR TITLE
[need #20] fix: surface actual error when provider client creation fails

### DIFF
--- a/pkg/maiao/factory.go
+++ b/pkg/maiao/factory.go
@@ -18,17 +18,20 @@ import (
 )
 
 func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) (api.PullRequester, error) {
+	var lastErr error
 	for _, u := range remote.Config().URLs {
 		ctx := log.WithContextFields(ctx, logrus.Fields{"remote-url": u})
 		endpoint, err := transport.NewEndpoint(u)
 		if err != nil {
 			log.ForContext(ctx).WithError(err).Errorf("failed to parse remote")
+			lastErr = err
 			continue
 		}
 
 		providerType, err := provider.Detect(endpoint.Host, repoPath)
 		if err != nil {
 			log.ForContext(ctx).WithError(err).Errorf("failed to detect provider")
+			lastErr = err
 			continue
 		}
 
@@ -37,6 +40,7 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := api.NewGitHubUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate github client")
+				lastErr = err
 				continue
 			}
 			return r, nil
@@ -44,6 +48,7 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := gitlab.NewGitLabUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate gitlab client")
+				lastErr = err
 				continue
 			}
 			return r, nil
@@ -51,6 +56,7 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := gitea.NewGiteaUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate gitea client")
+				lastErr = err
 				continue
 			}
 			return r, nil
@@ -58,6 +64,7 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := forgejo.NewForgejoUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate forgejo client")
+				lastErr = err
 				continue
 			}
 			return r, nil
@@ -65,12 +72,16 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := bitbucket.NewBitbucketUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate bitbucket client")
+				lastErr = err
 				continue
 			}
 			return r, nil
 		default:
 			return nil, fmt.Errorf("provider %q is not yet supported", providerType)
 		}
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed to create provider client: %w", lastErr)
 	}
 	return nil, errors.New("no supported provider found for remote")
 }


### PR DESCRIPTION
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
feat: add provider detection infrastructure for multi-provider support (<a href="https://github.com/runetes/maiao/pull/12">#12</a>)
</summary>
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
</details>
<details>
<summary>
feat: add provider-aware credential resolution (<a href="https://github.com/runetes/maiao/pull/13">#13</a>)
</summary>
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
</details>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
<details>
<summary>
feat: add Gitea pull request support (<a href="https://github.com/runetes/maiao/pull/15">#15</a>)
</summary>
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
</details>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
<details>
<summary>
feat: add Bitbucket Cloud pull request support (<a href="https://github.com/runetes/maiao/pull/17">#17</a>)
</summary>
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
</details>
<details>
<summary>
fix: auto-resolve SSH known_hosts errors with interactive prompt (<a href="https://github.com/runetes/maiao/pull/18">#18</a>)
</summary>
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
</details>
<details>
<summary>
docs: update documentation for multi-provider support (<a href="https://github.com/runetes/maiao/pull/19">#19</a>)
</summary>
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
</details>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
feat: add Cursor Origin provider support (beta) (<a href="https://github.com/runetes/maiao/pull/23">#23</a>)
</summary>
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
</details>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>