### PR TITLE
[need #21] feat: add Cursor Origin provider support (beta)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 > **Note:** This is a community fork of [adevinta/maiao](https://github.com/adevinta/maiao). The original maintainers are no longer at Adevinta and the upstream repository is no longer actively maintained. This fork continues development under [runetes/maiao](https://github.com/runetes/maiao).
 
-**Gerrit-style code review workflow for GitHub, GitLab, Gitea, Forgejo, and Bitbucket Cloud**
+**Gerrit-style code review workflow for GitHub, GitLab, Gitea, Forgejo, Bitbucket Cloud, and Cursor Origin**
 
 Maiao brings the power of **stacked pull requests** (or merge requests) to your git hosting provider, enabling you to break large features into small, reviewable commits where each commit becomes its own PR/MR.
 
@@ -31,8 +31,9 @@ Maiao provides the `git review` command that:
 | Gitea | Pull Request | `WIP:` title prefix | No |
 | Forgejo/Codeberg | Pull Request | `WIP:` title prefix | No |
 | Bitbucket Cloud | Pull Request | Not supported | No |
+| Cursor Origin (beta) | Pull Request | API field | Yes (`parentPullNumber`) |
 
-Maiao auto-detects the provider from your remote URL for known hosts (`github.com`, `gitlab.com`, `codeberg.org`, `bitbucket.org`). For self-hosted instances, it prompts on first use and saves the choice to `git config maiao.provider`.
+Maiao auto-detects the provider from your remote URL for known hosts (`github.com`, `gitlab.com`, `codeberg.org`, `bitbucket.org`, `origin.cursor.com`). For self-hosted instances, it prompts on first use and saves the choice to `git config maiao.provider`.
 
 ## Quick Example
 
@@ -61,7 +62,7 @@ git review
 - **Native Stacks**: Integrates with GitHub Stacks and GitLab's auto-detected stacks
 - **Merge Detection**: Stack updates automatically when PRs/MRs merge
 - **Rebase Integration**: Handles upstream changes gracefully
-- **Multi-Provider**: Works across GitHub, GitLab, Gitea, Forgejo, and Bitbucket Cloud
+- **Multi-Provider**: Works across GitHub, GitLab, Gitea, Forgejo, Bitbucket Cloud, and Cursor Origin
 
 ## Native GitHub Stacks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ Welcome to Maiao! This guide will help you set up and start using stacked pull r
 
 Before installing Maiao, ensure you have:
 - Git installed (version 2.0+)
-- An account on your git hosting provider (GitHub, GitLab, Gitea, Forgejo, or Bitbucket Cloud)
+- An account on your git hosting provider (GitHub, GitLab, Gitea, Forgejo, Bitbucket Cloud, or Cursor Origin)
 - An API token for your provider (see [Configuration](#-configuration) below)
 
 ## 📦 Installation
@@ -64,11 +64,12 @@ Maiao auto-detects your provider from the remote URL for known hosts:
 - `gitlab.com` → GitLab
 - `codeberg.org` → Forgejo
 - `bitbucket.org` → Bitbucket Cloud
+- `origin.cursor.com` → Cursor Origin
 
 For self-hosted instances, Maiao prompts you on first use and saves the choice:
 
 ```bash
-git config maiao.provider gitlab  # or: github, gitea, forgejo, bitbucket
+git config maiao.provider gitlab  # or: github, gitea, forgejo, bitbucket, origin
 ```
 
 ### Authentication
@@ -148,6 +149,25 @@ machine bitbucket.org
 ```
 
 Create an app password at [Bitbucket Settings → App passwords](https://bitbucket.org/account/settings/app-passwords/) with `Repositories: Read/Write` and `Pull requests: Read/Write` permissions.
+
+#### Cursor Origin (beta)
+
+> **Note:** Cursor Origin is currently in beta. The API and behavior may change.
+
+Cursor Origin uses a git credential helper installed by the Origin CLI. Maiao picks up the token automatically via `git credential fill`:
+
+```bash
+# Authenticate with Origin (one-time setup)
+origin auth login
+```
+
+Alternatively, you can set the token directly:
+
+```bash
+export ORIGIN_TOKEN=<your-origin-token>
+```
+
+Cursor Origin supports native stacking via `parentPullNumber` — Maiao uses this automatically when creating stacked PRs to register the parent-child relationship.
 
 ### 🔐 Experimental: System Keychain (Optional)
 

--- a/docs/how-does-it-work.md
+++ b/docs/how-does-it-work.md
@@ -2,7 +2,7 @@
 
 ## 🎯 Overview
 
-Maiao implements a **stacked diffs** workflow for GitHub, GitLab, Gitea, Forgejo, and Bitbucket Cloud, inspired by Gerrit's code review model. It transforms your linear commit history into individual, stacked pull requests (or merge requests) where each commit is independently reviewable while maintaining proper dependencies.
+Maiao implements a **stacked diffs** workflow for GitHub, GitLab, Gitea, Forgejo, Bitbucket Cloud, and Cursor Origin, inspired by Gerrit's code review model. It transforms your linear commit history into individual, stacked pull requests (or merge requests) where each commit is independently reviewable while maintaining proper dependencies.
 
 ## 📚 Background: Stacked Diffs
 
@@ -389,7 +389,7 @@ PR #3 base unchanged: maiao.I222 (rebased)
 
 Maiao detects the provider from your remote URL (`pkg/provider/detect.go`):
 
-1. **Known hosts** — `github.com`, `gitlab.com`, `codeberg.org`, `bitbucket.org` are mapped automatically
+1. **Known hosts** — `github.com`, `gitlab.com`, `codeberg.org`, `bitbucket.org`, `origin.cursor.com` are mapped automatically
 2. **Git config** — reads `git config maiao.provider` for self-hosted instances
 3. **Interactive prompt** — if unknown, prompts the user to select a provider and saves to git config
 
@@ -397,9 +397,9 @@ Maiao detects the provider from your remote URL (`pkg/provider/detect.go`):
 
 For each provider, Maiao tries credentials in order (`pkg/credentials/provider.go`):
 
-1. **Environment variable** — `GITHUB_TOKEN`, `GITLAB_TOKEN`, `GITEA_TOKEN`, `FORGEJO_TOKEN`, or `BITBUCKET_TOKEN` (+ `BITBUCKET_USERNAME`)
+1. **Environment variable** — `GITHUB_TOKEN`, `GITLAB_TOKEN`, `GITEA_TOKEN`, `FORGEJO_TOKEN`, `BITBUCKET_TOKEN` (+ `BITBUCKET_USERNAME`), or `ORIGIN_TOKEN`
 2. **Netrc** — `~/.netrc` machine entries
-3. **Git credential helpers** — whatever `git credential fill` returns
+3. **Git credential helpers** — whatever `git credential fill` returns (used by Cursor Origin's `origin auth login`)
 4. **System keychain** — macOS Keychain, pass, etc. (experimental)
 
 ### WIP/Draft Handling
@@ -409,6 +409,7 @@ Each provider handles work-in-progress differently:
 - **GitLab** — prefixes title with `Draft: `
 - **Gitea/Forgejo** — prefixes title with `WIP: `
 - **Bitbucket** — no draft support (logs a warning)
+- **Cursor Origin** — sets `draft: true` via the API
 
 Maiao strips `WIP:`/`Draft:` from commit titles, detects the intent, and lets each provider apply it in its own way.
 
@@ -477,8 +478,9 @@ Each provider implements this interface:
 - **Gitea** (`pkg/gitea/`) — REST v1 API with `Authorization: token` header
 - **Forgejo** (`pkg/forgejo/`) — embeds Gitea's base client
 - **Bitbucket Cloud** (`pkg/bitbucket/`) — REST 2.0 API with basic auth
+- **Cursor Origin** (`pkg/origin/`) — REST API with Bearer token auth; supports native stacking via `parentPullNumber`
 
-The `BodyFormatter` interface controls how PR body sections are rendered: HTML `<details>` for GitHub/GitLab/Gitea/Forgejo, Markdown headings for Bitbucket.
+The `BodyFormatter` interface controls how PR body sections are rendered: HTML `<details>` for GitHub/GitLab/Gitea/Forgejo/Origin, Markdown headings for Bitbucket.
 
 ### Force Push Strategy
 

--- a/pkg/api/pullRequester.go
+++ b/pkg/api/pullRequester.go
@@ -18,12 +18,13 @@ type PullRequester interface {
 
 // PullRequestOptions are the options available to create or update a pull request
 type PullRequestOptions struct {
-	Base  string
-	Head  string
-	Title string
-	Body  string
-	WIP   bool
-	Ready bool
+	Base             string
+	Head             string
+	Title            string
+	Body             string
+	WIP              bool
+	Ready            bool
+	ParentPullNumber string
 }
 
 // PullRequest defines the object

--- a/pkg/credentials/git.go
+++ b/pkg/credentials/git.go
@@ -22,6 +22,9 @@ func realRun(opts runOpts) (string, error) {
 	if opts.stdin != "" {
 		cmd.Stdin = strings.NewReader(opts.stdin)
 	}
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
 	return b.String(), nil
 }
 

--- a/pkg/credentials/provider.go
+++ b/pkg/credentials/provider.go
@@ -15,6 +15,7 @@ var envVarForProvider = map[string]providerEnvConfig{
 	"gitea":     {passwordKey: "GITEA_TOKEN"},
 	"forgejo":   {passwordKey: "FORGEJO_TOKEN"},
 	"bitbucket": {passwordKey: "BITBUCKET_TOKEN", usernameKey: "BITBUCKET_USERNAME"},
+	"origin":    {passwordKey: "ORIGIN_TOKEN"},
 }
 
 func CredentialGetterForProvider(providerType string) CredentialGetter {

--- a/pkg/maiao/factory.go
+++ b/pkg/maiao/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/adevinta/maiao/pkg/gitea"
 	"github.com/adevinta/maiao/pkg/gitlab"
 	"github.com/adevinta/maiao/pkg/log"
+	"github.com/adevinta/maiao/pkg/origin"
 	"github.com/adevinta/maiao/pkg/provider"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -72,6 +73,14 @@ func newPullRequester(ctx context.Context, remote *git.Remote, repoPath string) 
 			r, err := bitbucket.NewBitbucketUpserter(ctx, endpoint)
 			if err != nil {
 				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate bitbucket client")
+				lastErr = err
+				continue
+			}
+			return r, nil
+		case provider.Origin:
+			r, err := origin.NewOriginUpserter(ctx, endpoint)
+			if err != nil {
+				log.ForContext(ctx).WithError(err).Errorf("failed to instantiate origin client")
 				lastErr = err
 				continue
 			}

--- a/pkg/maiao/message.go
+++ b/pkg/maiao/message.go
@@ -83,12 +83,18 @@ func prOptions(repo lgit.Repository, prAPI api.PullRequester, options ReviewOpti
 		additions = append(additions, topicDetails(f, prAPI, options.Topic)...)
 	}
 
+	var parentPullNumber string
+	if change.parent != nil && change.parent.pr != nil {
+		parentPullNumber = change.parent.pr.ID
+	}
+
 	return api.PullRequestOptions{
-		Base:  base,
-		Head:  change.branch,
-		Title: title,
-		Body:  strings.Join(append([]string{change.message.Body}, additions...), "\n"),
-		Ready: options.Ready,
-		WIP:   wip,
+		Base:             base,
+		Head:             change.branch,
+		Title:            title,
+		Body:             strings.Join(append([]string{change.message.Body}, additions...), "\n"),
+		Ready:            options.Ready,
+		WIP:              wip,
+		ParentPullNumber: parentPullNumber,
 	}
 }

--- a/pkg/origin/origin.go
+++ b/pkg/origin/origin.go
@@ -1,0 +1,266 @@
+package origin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/api"
+	"github.com/adevinta/maiao/pkg/credentials"
+	"github.com/adevinta/maiao/pkg/log"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+type Origin struct {
+	Owner      string
+	Repo       string
+	HTTPClient *http.Client
+	apiBase    string
+	host       string
+}
+
+type pullRequestRef struct {
+	Ref string `json:"ref"`
+	SHA string `json:"sha"`
+}
+
+type pullRequest struct {
+	Number string         `json:"number"`
+	Title  string         `json:"title"`
+	Body   string         `json:"body"`
+	State  string         `json:"state"`
+	Draft  bool           `json:"draft"`
+	Head   pullRequestRef `json:"head"`
+	Base   pullRequestRef `json:"base"`
+}
+
+type listPullRequestsResponse struct {
+	PullRequests  []pullRequest `json:"pullRequests"`
+	NextPageToken string        `json:"nextPageToken"`
+}
+
+type repository struct {
+	DefaultBranch string `json:"defaultBranch"`
+}
+
+func NewOriginUpserter(ctx context.Context, endpoint *transport.Endpoint) (*Origin, error) {
+	orgRepo := strings.Split(strings.Trim(endpoint.Path, "/"), "/")
+	if len(orgRepo) != 2 {
+		return nil, fmt.Errorf("invalid repository path: %s (expected owner/repo)", endpoint.Path)
+	}
+
+	owner := orgRepo[0]
+	repo := strings.TrimSuffix(orgRepo[1], ".git")
+
+	credGetter := credentials.CredentialGetterForProvider("origin")
+	cred, err := credGetter.CredentialForHost(endpoint.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get credentials for %s: %w", endpoint.Host, err)
+	}
+
+	client := &http.Client{
+		Transport: &bearerTransport{
+			token:    cred.Password,
+			delegate: http.DefaultTransport,
+		},
+	}
+
+	return &Origin{
+		Owner:      owner,
+		Repo:       repo,
+		HTTPClient: client,
+		apiBase:    "https://api.cursor.com/v1/origin",
+		host:       endpoint.Host,
+	}, nil
+}
+
+type bearerTransport struct {
+	token    string
+	delegate http.RoundTripper
+}
+
+func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", "Bearer "+t.token)
+	return t.delegate.RoundTrip(req)
+}
+
+func (o *Origin) Ensure(ctx context.Context, options api.PullRequestOptions) (*api.PullRequest, bool, error) {
+	prs, err := o.listPRs(ctx, options.Head)
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch len(prs) {
+	case 0:
+		pr, err := o.createPR(ctx, options)
+		if err != nil {
+			return nil, false, err
+		}
+		return &api.PullRequest{
+			ID:  pr.Number,
+			URL: o.prURL(pr.Number),
+		}, true, nil
+	case 1:
+		return &api.PullRequest{
+			ID:  prs[0].Number,
+			URL: o.prURL(prs[0].Number),
+		}, false, nil
+	default:
+		return nil, false, fmt.Errorf("too many matching pull requests (%d)", len(prs))
+	}
+}
+
+func (o *Origin) Update(ctx context.Context, pr *api.PullRequest, options api.PullRequestOptions) (*api.PullRequest, error) {
+	body := map[string]interface{}{
+		"title": options.Title,
+		"body":  options.Body,
+		"base":  options.Base,
+	}
+	if options.WIP {
+		body["draft"] = true
+	} else if options.Ready {
+		body["draft"] = false
+	}
+
+	reqURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%s", o.apiBase, o.Owner, o.Repo, pr.ID)
+	resp, err := o.doJSON(ctx, http.MethodPatch, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to update pull request: %s %s", resp.Status, string(respBody))
+	}
+
+	var result pullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return &api.PullRequest{
+		ID:  result.Number,
+		URL: o.prURL(result.Number),
+	}, nil
+}
+
+func (o *Origin) DefaultBranch(ctx context.Context) string {
+	reqURL := fmt.Sprintf("%s/repos/%s/%s", o.apiBase, o.Owner, o.Repo)
+	resp, err := o.doRequest(ctx, http.MethodGet, reqURL)
+	if err != nil {
+		log.ForContext(ctx).WithError(err).Error("failed to get repository info")
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var r repository
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return ""
+	}
+	return r.DefaultBranch
+}
+
+func (o *Origin) LinkedTopicIssues(topicSearchString string) string {
+	values := url.Values{}
+	values.Add("q", topicSearchString)
+	return fmt.Sprintf("https://%s/%s/%s/pulls?%s", o.host, o.Owner, o.Repo, values.Encode())
+}
+
+func (o *Origin) prURL(number string) string {
+	return fmt.Sprintf("https://%s/%s/%s/pull/%s", o.host, o.Owner, o.Repo, number)
+}
+
+func (o *Origin) StackManager() api.StackManager {
+	return nil
+}
+
+func (o *Origin) BodyFormatter() api.BodyFormatter {
+	return api.HTMLBodyFormatter{}
+}
+
+func (o *Origin) listPRs(ctx context.Context, head string) ([]pullRequest, error) {
+	params := url.Values{}
+	params.Add("head", head)
+	params.Add("state", "open")
+	reqURL := fmt.Sprintf("%s/repos/%s/%s/pulls?%s", o.apiBase, o.Owner, o.Repo, params.Encode())
+
+	resp, err := o.doRequest(ctx, http.MethodGet, reqURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to list pull requests: %s %s", resp.Status, string(respBody))
+	}
+
+	var list listPullRequestsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		return nil, err
+	}
+	return list.PullRequests, nil
+}
+
+func (o *Origin) createPR(ctx context.Context, options api.PullRequestOptions) (*pullRequest, error) {
+	body := map[string]interface{}{
+		"title": options.Title,
+		"body":  options.Body,
+		"head":  options.Head,
+		"base":  options.Base,
+	}
+	if options.WIP {
+		body["draft"] = true
+	}
+	if options.ParentPullNumber != "" {
+		body["parentPullNumber"] = options.ParentPullNumber
+	}
+
+	reqURL := fmt.Sprintf("%s/repos/%s/%s/pulls", o.apiBase, o.Owner, o.Repo)
+	resp, err := o.doJSON(ctx, http.MethodPost, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to create pull request: %s %s", resp.Status, string(respBody))
+	}
+
+	var pr pullRequest
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+func (o *Origin) doJSON(ctx context.Context, method, reqURL string, body interface{}) (*http.Response, error) {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return o.HTTPClient.Do(req)
+}
+
+func (o *Origin) doRequest(ctx context.Context, method, reqURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return o.HTTPClient.Do(req)
+}

--- a/pkg/origin/origin_test.go
+++ b/pkg/origin/origin_test.go
@@ -1,0 +1,294 @@
+package origin
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/adevinta/maiao/pkg/api"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripperFunc func(r *http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+func newTestOrigin(rt http.RoundTripper) *Origin {
+	return &Origin{
+		Owner:      "owner",
+		Repo:       "repo",
+		HTTPClient: &http.Client{Transport: rt},
+		apiBase:    "https://api.cursor.com/v1/origin",
+		host:       "origin.cursor.com",
+	}
+}
+
+func TestEnsureReturnsExistingPR(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		body := `{"pullRequests": [{"number": "42", "state": "open", "head": {"ref": "maiao.abc123", "sha": "abc123"}}]}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, created, err := o.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	require.NoError(t, err)
+	assert.False(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "42", pr.ID)
+	assert.Equal(t, "https://origin.cursor.com/owner/repo/pull/42", pr.URL)
+}
+
+func TestEnsureCreatesNewPR(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodGet:
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"pullRequests": []}`))}, nil
+		case http.MethodPost:
+			var reqBody map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&reqBody)
+			assert.Equal(t, "Test PR", reqBody["title"])
+			assert.Equal(t, "maiao.abc123", reqBody["head"])
+			assert.Equal(t, "main", reqBody["base"])
+			body := `{"number": "99", "head": {"ref": "maiao.abc123", "sha": "def"}, "base": {"ref": "main", "sha": "abc"}}`
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(body))}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	}))
+
+	pr, created, err := o.Ensure(context.Background(), api.PullRequestOptions{
+		Head:  "maiao.abc123",
+		Base:  "main",
+		Title: "Test PR",
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "99", pr.ID)
+	assert.Equal(t, "https://origin.cursor.com/owner/repo/pull/99", pr.URL)
+}
+
+func TestEnsureCreatesNewPRWithParentPullNumber(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodGet:
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"pullRequests": []}`))}, nil
+		case http.MethodPost:
+			var reqBody map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&reqBody)
+			assert.Equal(t, "77", reqBody["parentPullNumber"])
+			body := `{"number": "100", "head": {"ref": "maiao.abc123", "sha": "def"}, "base": {"ref": "main", "sha": "abc"}}`
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(body))}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	}))
+
+	pr, created, err := o.Ensure(context.Background(), api.PullRequestOptions{
+		Head:             "maiao.abc123",
+		Base:             "main",
+		Title:            "Stacked PR",
+		ParentPullNumber: "77",
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "100", pr.ID)
+}
+
+func TestEnsureCreatesNewPRWithDraft(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.Method {
+		case http.MethodGet:
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"pullRequests": []}`))}, nil
+		case http.MethodPost:
+			var reqBody map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&reqBody)
+			assert.Equal(t, true, reqBody["draft"])
+			body := `{"number": "101", "draft": true, "head": {"ref": "maiao.abc123", "sha": "def"}, "base": {"ref": "main", "sha": "abc"}}`
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(body))}, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+			return nil, nil
+		}
+	}))
+
+	pr, created, err := o.Ensure(context.Background(), api.PullRequestOptions{
+		Head:  "maiao.abc123",
+		Base:  "main",
+		Title: "Draft PR",
+		WIP:   true,
+	})
+	require.NoError(t, err)
+	assert.True(t, created)
+	require.NotNil(t, pr)
+	assert.Equal(t, "101", pr.ID)
+}
+
+func TestEnsureReturnsErrorWhenTooManyPRs(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		body := `{"pullRequests": [{"number": "1", "head": {"ref": "a", "sha": "x"}}, {"number": "2", "head": {"ref": "b", "sha": "y"}}]}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, _, err := o.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	assert.Nil(t, pr)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many matching pull requests")
+}
+
+func TestEnsureReturnsErrorOnAPIFailure(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("error"))}, nil
+	}))
+
+	pr, _, err := o.Ensure(context.Background(), api.PullRequestOptions{Head: "maiao.abc123"})
+	assert.Nil(t, pr)
+	assert.Error(t, err)
+}
+
+func TestUpdatePR(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Contains(t, r.URL.Path, "/pulls/42")
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.Equal(t, "Updated Title", reqBody["title"])
+		assert.Equal(t, "Updated Body", reqBody["body"])
+		assert.Equal(t, "develop", reqBody["base"])
+		body := `{"number": "42", "head": {"ref": "feature", "sha": "abc"}, "base": {"ref": "develop", "sha": "def"}}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	pr, err := o.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "Updated Title",
+		Body:  "Updated Body",
+		Base:  "develop",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	assert.Equal(t, "42", pr.ID)
+}
+
+func TestUpdatePRMarkReady(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+		assert.Equal(t, false, reqBody["draft"])
+		body := `{"number": "42", "head": {"ref": "feature", "sha": "abc"}, "base": {"ref": "main", "sha": "def"}}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	_, err := o.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "Title",
+		Base:  "main",
+		Ready: true,
+	})
+	require.NoError(t, err)
+}
+
+func TestUpdateReturnsErrorOnAPIFailure(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader("forbidden"))}, nil
+	}))
+
+	_, err := o.Update(context.Background(), &api.PullRequest{ID: "42"}, api.PullRequestOptions{
+		Title: "Title",
+		Base:  "main",
+	})
+	assert.Error(t, err)
+}
+
+func TestDefaultBranch(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/repos/owner/repo")
+		body := `{"defaultBranch": "main"}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}))
+
+	branch := o.DefaultBranch(context.Background())
+	assert.Equal(t, "main", branch)
+}
+
+func TestDefaultBranchReturnsEmptyOnError(t *testing.T) {
+	o := newTestOrigin(roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}))
+
+	branch := o.DefaultBranch(context.Background())
+	assert.Equal(t, "", branch)
+}
+
+func TestLinkedTopicIssues(t *testing.T) {
+	o := &Origin{host: "origin.cursor.com", Owner: "owner", Repo: "repo"}
+	result := o.LinkedTopicIssues("topic-sha")
+	assert.Contains(t, result, "origin.cursor.com/owner/repo/pulls")
+	assert.Contains(t, result, "q=topic-sha")
+}
+
+func TestStackManagerReturnsNil(t *testing.T) {
+	o := &Origin{}
+	assert.Nil(t, o.StackManager())
+}
+
+func TestBodyFormatterReturnsHTML(t *testing.T) {
+	o := &Origin{}
+	f := o.BodyFormatter()
+	assert.IsType(t, api.HTMLBodyFormatter{}, f)
+}
+
+func TestBearerTransportSetsHeader(t *testing.T) {
+	var capturedAuth string
+	tr := &bearerTransport{
+		token: "my-token",
+		delegate: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			capturedAuth = r.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.cursor.com/v1/origin/repos", nil)
+	tr.RoundTrip(req)
+	assert.Equal(t, "Bearer my-token", capturedAuth)
+}
+
+func TestNewOriginUpserterInvalidPath(t *testing.T) {
+	o, err := NewOriginUpserter(context.Background(), &transport.Endpoint{Host: "origin.cursor.com", Path: "invalid"})
+	assert.Error(t, err)
+	assert.Nil(t, o)
+}
+
+func TestNewOriginUpserterValidPath(t *testing.T) {
+	old := os.Getenv("ORIGIN_TOKEN")
+	defer os.Setenv("ORIGIN_TOKEN", old)
+	os.Setenv("ORIGIN_TOKEN", "test-token")
+
+	o, err := NewOriginUpserter(context.Background(), &transport.Endpoint{Host: "origin.cursor.com", Path: "/owner/repo.git"})
+	require.NoError(t, err)
+	require.NotNil(t, o)
+	assert.Equal(t, "owner", o.Owner)
+	assert.Equal(t, "repo", o.Repo)
+	assert.Equal(t, "https://api.cursor.com/v1/origin", o.apiBase)
+	assert.Equal(t, "origin.cursor.com", o.host)
+}
+
+func TestNewOriginUpserterNoCredentials(t *testing.T) {
+	old := os.Getenv("ORIGIN_TOKEN")
+	defer os.Setenv("ORIGIN_TOKEN", old)
+	os.Unsetenv("ORIGIN_TOKEN")
+
+	o, err := NewOriginUpserter(context.Background(), &transport.Endpoint{Host: "no-cred-host.example.com", Path: "/owner/repo"})
+	assert.Error(t, err)
+	assert.Nil(t, o)
+}

--- a/pkg/provider/detect.go
+++ b/pkg/provider/detect.go
@@ -62,6 +62,7 @@ func promptForProvider(host string) (Type, error) {
 		string(Gitea),
 		string(Forgejo),
 		string(Bitbucket),
+		string(Origin),
 	}
 	label := fmt.Sprintf("Detected remote host: %s. Which provider is this?", host)
 	idx, err := prompt.Select(label, items)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -8,16 +8,18 @@ const (
 	Gitea     Type = "gitea"
 	Forgejo   Type = "forgejo"
 	Bitbucket Type = "bitbucket"
+	Origin    Type = "origin"
 )
 
 var KnownHosts = map[string]Type{
-	"github.com":    GitHub,
-	"gitlab.com":    GitLab,
-	"codeberg.org":  Forgejo,
-	"bitbucket.org": Bitbucket,
+	"github.com":        GitHub,
+	"gitlab.com":        GitLab,
+	"codeberg.org":      Forgejo,
+	"bitbucket.org":     Bitbucket,
+	"origin.cursor.com": Origin,
 }
 
-var AllTypes = []Type{GitHub, GitLab, Gitea, Forgejo, Bitbucket}
+var AllTypes = []Type{GitHub, GitLab, Gitea, Forgejo, Bitbucket, Origin}
 
 func (t Type) String() string {
 	return string(t)
@@ -25,7 +27,7 @@ func (t Type) String() string {
 
 func ParseType(s string) (Type, bool) {
 	switch Type(s) {
-	case GitHub, GitLab, Gitea, Forgejo, Bitbucket:
+	case GitHub, GitLab, Gitea, Forgejo, Bitbucket, Origin:
 		return Type(s), true
 	default:
 		return "", false


### PR DESCRIPTION
Implements PullRequester for Cursor Origin with bearer token auth,
native stacking via parentPullNumber, and draft PR support. Also fixes
git credential helper not being invoked (cmd.Run was missing).
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
feat: add provider detection infrastructure for multi-provider support (<a href="https://github.com/runetes/maiao/pull/12">#12</a>)
</summary>
Overall context
=====

This is PR 1/6 of the multi-provider support initiative. Maiao currently
only supports GitHub for stacked diffs. We are extending it to support
GitLab, Gitea, Forgejo, and Bitbucket Cloud.

Problem
=====

The NewPullRequester factory is hardcoded to GitHub. There is no mechanism
to detect which git hosting provider a remote URL belongs to, nor any way
for users to configure their provider for self-hosted instances.

Goal
=====

Introduce provider detection infrastructure that auto-detects known hosts
(github.com, gitlab.com, codeberg.org, bitbucket.org), reads from git
config for self-hosted instances, and interactively prompts when neither
applies — similar to the existing Gerrit hook installation UX.

Solution
=====

- New pkg/provider package with Type constants, KnownHosts map, and
  Detect() function that checks known hosts → git config → interactive
  prompt → saves to git config
- New prompt.Select() function using promptui.Select for the interactive
  provider selection flow
- Refactored NewPullRequester() to accept repoPath and dispatch based on
  detected provider type (currently only GitHub, others return "not yet
  supported")
- Pass RepoPath from cmd layer through ReviewOptions to the factory
</details>
<details>
<summary>
feat: add provider-aware credential resolution (<a href="https://github.com/runetes/maiao/pull/13">#13</a>)
</summary>
Overall context
=====

This is PR 2/6 of the multi-provider support initiative. After PR 1
introduced provider detection, this commit makes credential resolution
provider-aware so each provider uses its own environment variable and
credential chain.

Problem
=====

The credential getter in review.go is hardcoded to use
gh.DefaultCredentialGetter which only looks for GITHUB_TOKEN. When
supporting GitLab, Gitea, Forgejo, and Bitbucket, each needs its own
token environment variable (GITLAB_TOKEN, GITEA_TOKEN, etc.).

Goal
=====

Replace the hardcoded GitHub credential getter with a provider-aware
credential factory that builds the appropriate chain (env var → netrc →
git credential → keyring) based on the detected provider type.

Solution
=====

- New credentials.CredentialGetterForProvider(providerType string) that
  maps provider types to their env vars and constructs the chain
- Replaced both gh.DefaultCredentialGetter references in review.go with
  provider-aware resolution using the already-detected provider type
- Removed the pkg/github import from review.go (no longer needed)
- GitHub behavior remains identical (backward compatible)
</details>
<details>
<summary>
feat: add GitLab merge request support (<a href="https://github.com/runetes/maiao/pull/14">#14</a>)
</summary>
Overall context
=====

This is PR 3/6 of the multi-provider support initiative. With provider
detection (PR 1) and credential abstraction (PR 2) in place, this adds
the first non-GitHub provider: GitLab.

Problem
=====

Users working with GitLab repositories cannot use git-review to manage
stacked merge requests. The factory was also in pkg/api which caused an
import cycle when adding provider implementations that depend on the
api.PullRequester interface.

Goal
=====

Implement the PullRequester interface for GitLab using its REST v4 API,
and resolve the import cycle by moving the provider factory to pkg/maiao.

Solution
=====

- New pkg/gitlab package implementing PullRequester with GitLab REST v4
  API (list/create/update merge requests, get default branch)
- Draft/WIP support via "Draft: " title prefix
- URL-encoded project path for GitLab's nested group support
- Token auth via PRIVATE-TOKEN header
- Moved NewPullRequester factory from pkg/api to pkg/maiao/factory.go
  (resolves import cycle: api <- gitlab <- api)
- Wired GitLab case into the factory dispatch
- StackManager returns nil (no native stack support)
</details>
<details>
<summary>
feat: add Gitea pull request support (<a href="https://github.com/runetes/maiao/pull/15">#15</a>)
</summary>
Overall context
=====

This is PR 4/6 of the multi-provider support initiative. This adds Gitea
support with a shared BaseClient that will also be used by the Forgejo
implementation in the next PR.

Problem
=====

Users working with Gitea instances cannot use git-review to manage
stacked pull requests.

Goal
=====

Implement the PullRequester interface for Gitea using its REST v1 API,
with the implementation structured as a reusable BaseClient that Forgejo
can embed.

Solution
=====

- New pkg/gitea/base.go with BaseClient implementing PullRequester via
  Gitea/Forgejo REST v1 API (/api/v1/repos/{owner}/{repo}/pulls)
- New pkg/gitea/gitea.go with Gitea struct embedding BaseClient and
  constructor with token auth via Authorization header
- WIP support via "WIP: " title prefix
- Client-side head ref filtering (Gitea API lacks server-side filter)
- StackManager returns nil (no native stack support)
- Wired into factory dispatch
</details>
<details>
<summary>
feat: add Forgejo pull request support (<a href="https://github.com/runetes/maiao/pull/16">#16</a>)
</summary>
Overall context
=====

This is PR 5/6 of the multi-provider support initiative. This adds
Forgejo support as a thin wrapper over the Gitea BaseClient, since
their APIs are currently identical but may diverge in the future.

Problem
=====

Users working with Forgejo instances (including Codeberg) cannot use
git-review to manage stacked pull requests.

Goal
=====

Implement Forgejo as a separate provider type that shares the Gitea
BaseClient, and add codeberg.org to the known hosts map.

Solution
=====

- New pkg/forgejo package with Forgejo struct embedding gitea.BaseClient
- Separate constructor using FORGEJO_TOKEN credential resolution
- codeberg.org already mapped to Forgejo in the KnownHosts map (PR 1)
- Wired into factory dispatch
- Separate type allows future API divergence without breaking changes
</details>
<details>
<summary>
feat: add Bitbucket Cloud pull request support (<a href="https://github.com/runetes/maiao/pull/17">#17</a>)
</summary>
Overall context
=====

This is PR 6/6 of the multi-provider support initiative. This completes
multi-provider support by adding Bitbucket Cloud as the final provider.

Problem
=====

Users working with Bitbucket Cloud repositories cannot use git-review to
manage stacked pull requests.

Goal
=====

Implement the PullRequester interface for Bitbucket Cloud using its REST
2.0 API, completing the multi-provider support initiative.

Solution
=====

- New pkg/bitbucket package implementing PullRequester with Bitbucket
  Cloud REST 2.0 API (/2.0/repositories/{workspace}/{slug}/pullrequests)
- Basic auth via username:app-password (BITBUCKET_TOKEN env var)
- Server-side query filtering for PRs by source branch
- Bitbucket has no draft/WIP support — logs a warning when --wip is used
- Paginated response handling via Bitbucket's {values: [...]} envelope
- StackManager returns nil (no native stack support)
- bitbucket.org already mapped in KnownHosts (PR 1)
- Wired into factory dispatch
</details>
<details>
<summary>
fix: auto-resolve SSH known_hosts errors with interactive prompt (<a href="https://github.com/runetes/maiao/pull/18">#18</a>)
</summary>
Overall context
=====

This is a UX improvement discovered during manual testing of the
multi-provider support. When users clone a repo via SSH and run
git-review for the first time, go-git's knownhosts library is stricter
than OpenSSH and often fails with key mismatches or unknown host errors.

Problem
=====

go-git's SSH transport fails with "knownhosts: key mismatch" or
"knownhosts: key is unknown" when the server presents a key type not in
~/.ssh/known_hosts. OpenSSH handles this gracefully, but go-git does
not, requiring users to manually run ssh-keyscan.

Goal
=====

Automatically detect SSH known_hosts errors and offer to fix them
interactively, using the same Y/N prompt pattern as the Gerrit hook
installation.

Solution
=====

- New pkg/ssh package with IsKnownHostsError() detection and
  PromptAndFix() resolution (ssh-keygen -R + ssh-keyscan)
- Wrapped fetch and push calls in review.go with retry-after-fix logic
- On mismatch: "SSH host key mismatch for X. Update it? [y/N]"
- On unknown: "SSH host key not found for X. Add it automatically? [y/N]"
- Falls back to the endpoint host when the error message doesn't contain
  a parseable hostname
</details>
<details>
<summary>
docs: update documentation for multi-provider support (<a href="https://github.com/runetes/maiao/pull/19">#19</a>)
</summary>
Overall context: Maiao now supports GitHub, GitLab, Gitea, Forgejo, and
Bitbucket Cloud, but all documentation still read as GitHub-only.

"GitHub Personal Access Token", and exclusive GitHub API examples don't
reflect the multi-provider reality.

per-provider setup requirements.

Solution:
- Update taglines and descriptions to mention all providers
- Add "Supported Providers" table to README
- Restructure getting-started Configuration into per-provider sections
- Add provider detection and SSH troubleshooting docs
- Add Provider Architecture section to how-does-it-work
- Remove duplicate installation/configuration content
- Note GitLab's auto-detected stacks (up to 20 MRs)
</details>
<details>
<summary>
fix: auto-resolve missing remote HEAD ref for default branch detection (<a href="https://github.com/runetes/maiao/pull/20">#20</a>)
</summary>
Overall context: When a repository is created via `git init` + `git
remote add` (rather than `git clone`), `refs/remotes/origin/HEAD` is
not set, causing default branch detection to fail.

doesn't exist, falling back to "master" even if the repo uses "main".
This produces a "reference not found" error.

`git remote set-head <remote> --auto` to query the remote for its
default branch, then retry the symbolic-ref lookup.
</details>
<details>
<summary>
fix: surface actual error when provider client creation fails (<a href="https://github.com/runetes/maiao/pull/21">#21</a>)
</summary>
Previously, if a provider was detected but client instantiation failed
(e.g., missing credentials), the error was logged but the user only
saw "no supported provider found for remote". Now the underlying error
is returned directly, making it clear what needs to be fixed.
</details>
</details>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
fix: handle GitHub native stacks base branch conflict (<a href="https://github.com/runetes/maiao/pull/24">#24</a>)
</summary>
Problem
=======

When a PR is part of a GitHub native stack, updating its base branch via
the regular PR API fails with "Cannot change the base branch because the
pull request is part of a stack." This blocks `git review` from updating
existing stacked PRs.

Goal
====

Allow `git review` to work seamlessly with GitHub native stacks, using
the Stacks API to manage base branches and add new PRs to existing
stacks.

Solution
========

- In `Update`, detect the stacked base error and retry without the base
  field — the stack manages base branches automatically via PR ordering.
- In `CreateOrUpdateStack`, when a stack already exists, use
  `POST /stacks/{stack_number}/add` to append only the new PRs that
  aren't already in the stack (no-op if all are present).
- Use `stack_number` (not `id`) as the Stack identifier since it's what
  the API endpoints expect in URL paths.
- Add `DeleteStack` to the `StackManager` interface for future use.
</details>
</details>
</details>