### PR TITLE
ci: add GitHub token [skip ci]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,6 @@ jobs:
     steps:
     - uses: googleapis/release-please-action@v4
       with:
+        token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         config-file: release-please-config.json
         manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Problem
=====

GitHub doesn't allow to trigger a workflow from another one. Hence,
`release.yaml` is not triggered after `release-please.yaml`.

Goal
=====

To have automated releases. Based on the [action's documentation](https://github.com/googleapis/release-please-action)
you can achieve it with a Personal Access Token (PAT)

Solution
=====

Add a PAT to allow for the release.
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>