### PR TITLE
fix: open linked worktrees through the git common dir

### DIFF
--- a/pkg/cmd/review.go
+++ b/pkg/cmd/review.go
@@ -19,7 +19,14 @@ const (
 
 func review(cmd *cobra.Command, args []string) error {
 	path := cmd.Flag("path").Value.String()
-	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{DetectDotGit: true})
+	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
+		DetectDotGit: true,
+		// A linked worktree's .git points at .git/worktrees/<name>, which holds
+		// HEAD but keeps refs and config in the common dir named beside it.
+		// Without this, resolving what HEAD points at fails with
+		// "reference not found".
+		EnableDotGitCommonDir: true,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## The failure

`git review` cannot run from a linked worktree. Every invocation stops at:

```
level=error msg="failed to retrieve git HEAD" error="reference not found"
```

Reproducible from a clean state:

```sh
git init -b main repo && cd repo
git commit --allow-empty -m base
git remote add origin https://github.com/example/example.git
git worktree add ../wt -b feature
cd ../wt && git commit --allow-empty -m work   # with the commit-msg hook installed
git review main                                 # reference not found
```

## Why

A linked worktree's `.git` is a file pointing at `.git/worktrees/<name>`. That
directory holds `HEAD`, but `refs/` and `config` stay in the common directory,
named by the `commondir` file beside it.

`pkg/cmd/review.go` opens the repository with `DetectDotGit` alone. go-git only
follows `commondir` when `EnableDotGitCommonDir` is set, and that is still gated
in the pinned v5.16.2 (and in v5.19.0, so the pending bump does not change this).
So `HEAD` reads as `ref: refs/heads/<branch>`, the lookup for that ref goes to the
worktree directory, and it is not there.

The same omission also hides the remotes: with refs planted by hand, the next
error is `remote not found`, because `config` is in the common directory too.

## The fix

Set `EnableDotGitCommonDir: true`. Refs and config then come from the common
directory, while the worktree's own `HEAD` still comes from the worktree, which is
exactly git's own layout.

`pkg/cmd/rebase.go` has the only other `PlainOpen` call and it is commented out,
so this is the single live call site.

## Verification

Against a scratch linked worktree:

| | result |
| --- | --- |
| before | `failed to retrieve git HEAD` / `reference not found` |
| after | `headSHA=<the worktree's true head>`, then on to the provider client |

Also confirmed against a real 23-commit stack in a linked worktree, where it now
reads the correct stack tip.

`go build ./...` is clean. `go test ./...` is unchanged by this commit: `pkg/github`
fails identically on unpatched `main`, and every other package passes.

## A note for anyone who hits this before it lands

Planting `refs/heads/<branch>` and `config` into `.git/worktrees/<name>/` does get
the tool running, and it is not safe. Git never updates those copies, so after the
next commit the tool reads the stale SHA and would push the wrong commit with no
error.
